### PR TITLE
Changes required to compile on emscripten target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,15 @@ configure_project()
 print_config()
 
 # core libraries
-add_subdirectory(libethash)
-add_subdirectory(libethcore)
-add_subdirectory(libevmcore)
+if (NOT EMSCRIPTEN)
+	add_subdirectory(libethash)
+	add_subdirectory(libethcore)
+	add_subdirectory(libevmcore)
+	add_subdirectory(liblll)
+	add_subdirectory(libevm)
+	add_subdirectory(libethereum)
+endif()
 add_subdirectory(libevmasm)
-add_subdirectory(liblll)
-add_subdirectory(libevm)
-add_subdirectory(libethereum)
 
 if (ETHASHCL)
 	add_subdirectory(libethash-cl)
@@ -37,7 +39,9 @@ endif()
 
 # other libraries
 add_subdirectory(libnatspec)
-add_subdirectory(libtestutils)
+if (NOT EMSCRIPTEN)
+	add_subdirectory(libtestutils)
+endif()
 
 # executables
 

--- a/libethereum/CMakeLists.txt
+++ b/libethereum/CMakeLists.txt
@@ -7,7 +7,10 @@ set(EXECUTABLE ethereum)
 file(GLOB HEADERS "*.h")
 
 add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
-eth_use(${EXECUTABLE} REQUIRED Eth::evm Eth::lll Dev::p2p Dev::devcrypto Eth::ethcore JsonRpc::Server JsonRpc::Client)
+eth_use(${EXECUTABLE} REQUIRED Eth::evm Eth::ethcore)
+if (NOT EMSCRIPTEN)
+	eth_use(${EXECUTABLE} REQUIRED Eth::lll Dev::p2p Dev::devcrypto JsonRpc::Server JsonRpc::Client)
+endif()
 target_link_libraries(${EXECUTABLE} ${Boost_REGEX_LIBRARIES})
 
 jsonrcpstub_client_create(Sentinel.json dev::eth::Sentinel Sentinel)


### PR DESCRIPTION
This change parametrically excludes some subdirectories from cmake and strips down dependencies so that solidity can be compiled for the emscripten javascript target.
