### PR TITLE
sstore underflow test

### DIFF
--- a/test/libevm/VMTestsFiller/vmIOandFlowOperationsTestFiller.json
+++ b/test/libevm/VMTestsFiller/vmIOandFlowOperationsTestFiller.json
@@ -727,6 +727,41 @@
         }
     },
 
+    "sstore_underflow": {
+        "env" : {
+        "previousHash" : "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6",
+        "currentNumber" : "0",
+        "currentGasLimit" : "1000000",
+        "currentDifficulty" : "256",
+        "currentTimestamp" : "1",
+        "currentCoinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba"
+        },
+        "expect" : {
+            "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "storage" : {
+                    "0x01" : "0x00"
+                }
+            }
+        },
+        "pre" : {
+        "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+            "balance" : "100000000000000000000000",
+            "nonce" : "0",
+            "code" : "0x600155",
+            "storage": {}
+        }
+        },
+        "exec" : {
+            "address" : "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "origin" : "cd1722f3947def4cf144679da39c4c32bdc35681",
+            "caller" : "cd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "1000000000000000000",
+            "data" : "",
+            "gasPrice" : "100000000000000",
+            "gas" : "100000"
+        }
+    },
+
     "sstore_load_1": {
         "env" : {
         "previousHash" : "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6",


### PR DESCRIPTION
add missing consensus test to get full coverage for evm
copy of https://github.com/ethereum/cpp-ethereum/pull/2966
