### PR TITLE
Backport: Fix EVMJIT cache path on Windows

### DIFF
--- a/evmjit/libevmjit/Cache.cpp
+++ b/evmjit/libevmjit/Cache.cpp
@@ -152,8 +152,11 @@ void ObjectCache::notifyObjectCompiled(llvm::Module const* _module, llvm::Memory
 
 	auto&& id = _module->getModuleIdentifier();
 	llvm::SmallString<256> cachePath{getVersionedCacheDir()};
-	if (llvm::sys::fs::create_directories(cachePath))
-		DLOG(cache) << "Cannot create cache dir " << cachePath.str().str() << "\n";
+	if (auto err = llvm::sys::fs::create_directories(cachePath))
+	{
+		DLOG(cache) << "Cannot create cache dir " << cachePath.str().str() << " (error: " << err.message() << "\n";
+		return;
+	}
 
 	llvm::sys::path::append(cachePath, id);
 

--- a/evmjit/libevmjit/support/Path.cpp
+++ b/evmjit/libevmjit/support/Path.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 
 #if UTILS_OS_WINDOWS
+#define _WIN32_WINNT _WIN32_WINNT_VISTA // Override minimum Windows API version. FIXME: Do it better.
 #include <ShlObj.h>
 #endif
 
@@ -14,9 +15,7 @@ namespace path
 		#if UTILS_OS_POSIX
 			return std::getenv("HOME");
 		#elif UTILS_OS_WINDOWS
-			char pathBuf[MAX_PATH];
-			if (SHGetSpecialFolderPathA(nullptr, pathBuf, CSIDL_LOCAL_APPDATA, true))
-				return pathBuf;
+			// Not needed on Windows
 		#else
 			static_assert(false, "Unsupported OS");
 		#endif
@@ -38,9 +37,14 @@ namespace path
 			if (!home.empty())
 				return home + "/Library/Caches";
 		#elif UTILS_OS_WINDOWS
-			char pathBuf[MAX_PATH];
-			if (SHGetSpecialFolderPathA(nullptr, pathBuf, CSIDL_LOCAL_APPDATA, true))
-				return pathBuf;
+			wchar_t* utf16Path = nullptr;
+			if (SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &utf16Path) != S_OK)
+				return {};
+
+			char utf8Path[4 * MAX_PATH];
+			int len = WideCharToMultiByte(CP_UTF8, 0, utf16Path, lstrlenW(utf16Path), utf8Path, sizeof(utf8Path), nullptr, nullptr);
+			CoTaskMemFree(utf16Path);
+			return {utf8Path, len};
 		#else
 			static_assert(false, "Unsupported OS");
 		#endif


### PR DESCRIPTION
Backport "Fix EVMJIT cache path on Windows" to 1.0 release.

DEPENDS:
{
    "libweb3core":"release",
    "webthree":"release",
    "webthreehelpers":"release",
    "web3js":release"release",
    "solidity":"release",
    "alethzero":"release",
    "mix": "release"
}
