### PR TITLE
add removed unique_ptr.get() back

### DIFF
--- a/evmjit/libevmjit/Cache.cpp
+++ b/evmjit/libevmjit/Cache.cpp
@@ -118,7 +118,7 @@ std::unique_ptr<llvm::Module> Cache::getObject(std::string const& id)
 	llvm::sys::path::append(cachePath, id);
 
 	if (auto r = llvm::MemoryBuffer::getFile(cachePath, -1, false))
-		g_lastObject = llvm::MemoryBuffer::getMemBufferCopy(r->getBuffer());
+		g_lastObject = llvm::MemoryBuffer::getMemBufferCopy(r.get()->getBuffer());
 	else if (r.getError() != std::make_error_code(std::errc::no_such_file_or_directory))
 		DLOG(cache) << r.getError().message(); // TODO: Add warning log
 

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -58,7 +58,7 @@ EthashClient::EthashClient(
 
 Ethash* EthashClient::sealEngine() const
 {
-	return dynamic_cast<Ethash*>(sealEngine());
+	return dynamic_cast<Ethash*>(Client::sealEngine());
 }
 
 bool EthashClient::isMining() const

--- a/libethcore/BasicAuthority.h
+++ b/libethcore/BasicAuthority.h
@@ -40,7 +40,7 @@ public:
 
 	void populateFromParent(BlockHeader&, BlockHeader const&) const override;
 	StringHashMap jsInfo(BlockHeader const& _bi) const override;
-	void verify(Strictness _s, BlockHeader const& _bi, BlockHeader const& _parent, bytesConstRef _block) const;
+	void verify(Strictness _s, BlockHeader const& _bi, BlockHeader const& _parent, bytesConstRef _block) const override;
 	void generateSeal(BlockHeader const& _bi) override;
 
 	static Signature sig(BlockHeader const& _bi) { return _bi.seal<Signature>(); }

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -36,7 +36,7 @@ namespace eth
 {
 
 class BlockHeader;
-class ChainOperationParams;
+struct ChainOperationParams;
 class Interface;
 
 class SealEngineFace

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -203,8 +203,8 @@ protected:
 	void init(p2p::Host* _extNet, std::string const& _dbPath, WithExisting _forceAction, u256 _networkId);
 
 	/// InterfaceStub methods
-	BlockChain& bc() { return m_bc; }
-	BlockChain const& bc() const { return m_bc; }
+	BlockChain& bc() override { return m_bc; }
+	BlockChain const& bc() const override { return m_bc; }
 
 	/// Returns the state object for the full block (i.e. the terminal state) for index _h.
 	/// Works properly with LatestBlock and PendingBlock.


### PR DESCRIPTION
DONTBUILD

The get() is needed here because llvm::MemoryBuffer::getFile() does not
actually return a simple unique_ptr but instead returns an `ErrorOr`
construct and as such the compiler needs to first get the pointer and
then get the function of the file. Else it does not compile.

Here is the error I was getting

```
[ 13%] Building CXX object evmjit/libevmjit/CMakeFiles/evmjit.dir/Endianness.cpp.o
/home/lefteris/ew2/libethereum/evmjit/libevmjit/Cache.cpp:121:58: error: no member named 'getBuffer' in 'std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer> >'
                g_lastObject = llvm::MemoryBuffer::getMemBufferCopy(r->getBuffer());
```

Here is the function signature

```
  static ErrorOr<std::unique_ptr<MemoryBuffer>>
  getFile(const Twine &Filename, int64_t FileSize = -1,
          bool RequiresNullTerminator = true, bool IsVolatileSize =
          false);
```

Plus other fixes in the next commits.
