### PR TITLE
Overcome link-to-self for cmake 3.4.0 - build fix

### DIFF
--- a/libethash-cl/CMakeLists.txt
+++ b/libethash-cl/CMakeLists.txt
@@ -19,6 +19,8 @@ aux_source_directory(. SRC_LIST)
 file(GLOB OUR_HEADERS "*.h")
 set(HEADERS ${OUR_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/ethash_cl_miner_kernel.h)
 
+# TODO: Should fix properly. Cmake >= 3.4.0 detects a self linking of ethash-cl library here.
+cmake_policy(SET CMP0038 OLD)
 add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 eth_use(${EXECUTABLE} REQUIRED Eth::ethash OpenCL)
 target_include_directories(${EXECUTABLE} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
For cmake 3.4.0 there is an error inside libethash-cl CmakeList.txt.

```
CMake Error at libethash-cl/CMakeLists.txt:22 (add_library):
  Target "ethash-cl" links to itself.

CMake Error at libethash-cl/CMakeLists.txt:22 (add_library):
  Target "ethash-cl" links to itself.
```

According to https://cmake.org/cmake/help/v3.4/policy/CMP0038.html from
cmake 3.4.0 and afterwards it becomes an error for a library to link to
one's self.

Setting the policy to stick to the old way (before 3.4.0) allows
compilation to continue with the new cmake.

This is a build fix but not a proper fix since I can't figure out by just a quick look why cmake thinks
that `add_library()` causes a self-linking there.
