### PR TITLE
add callGas cost to delegatecall

### DIFF
--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -159,9 +159,7 @@ void VM::checkRequirements(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp,
 	case Instruction::CALLCODE:
 	case Instruction::DELEGATECALL:
 	{
-		runGas = (bigint)m_stack[m_stack.size() - 1];
-		if (_inst != Instruction::DELEGATECALL)
-			runGas += m_schedule.callGas;
+		runGas = (bigint)m_stack[m_stack.size() - 1] + m_schedule.callGas;
 
 		if (_inst == Instruction::CALL && !_ext.exists(asAddress(m_stack[m_stack.size() - 2])))
 			runGas += m_schedule.callNewAccountGas;


### PR DESCRIPTION
The normale `CALL`gas cost should still be paid. Otherwise someone could run an attack with an enormous amount of `DELEGATECALL` opcodes, calling an arbitrary address and setting gas to zero.
Also https://github.com/ethereum/EIPs/issues/23 specifies that `callGas` should be paid.
