### PR TITLE
Fix invalid nonce bug in ethvm

### DIFF
--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
 	string incoming = "--";
 
 	Mode mode = Mode::Statistics;
-	State state(Invalid256);
+	State state(0);
 	Address sender = Address(69);
 	Address origin = Address(69);
 	u256 value = 0;


### PR DESCRIPTION
Before this change ethvm was always crashing with

```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<dev::eth::InvalidAccountStartNonceInState>'
  what():  InvalidAccountStartNonceInState

```

this PR fixes it
