### PR TITLE
Vmtracefix

### DIFF
--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -827,6 +827,10 @@ Options::Options(int argc, char** argv)
 				logVerbosity = Verbosity::NiceReport;
 			else
 				logVerbosity = Verbosity::Full;
+
+			int indentLevelInt = atoi(argv[i + 1]);
+			if (indentLevelInt > g_logVerbosity)
+				g_logVerbosity = indentLevelInt;
 		}
 		else if (arg == "--createRandomTest")
 			createRandomTest = true;


### PR DESCRIPTION
VMTrace was not working correctly in testeth
now --verbosity options sets the global log verbosity so that vmtrace would go to the output

example test
-t VMTests/vmtests --singletest suicide --vmtrace --sealengine Homestead --verbosity 13
