### PR TITLE
Reduce stack size for calls.

### DIFF
--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -215,7 +215,7 @@ int main(int argc, char** argv)
 		cout << total << " operations in " << execTime << " seconds." << endl;
 		cout << "Maximum memory usage: " << memTotal * 32 << " bytes" << endl;
 		cout << "Expensive operations:" << endl;
-		for (auto const& c: {Instruction::SSTORE, Instruction::SLOAD, Instruction::CALL, Instruction::CREATE, Instruction::CALLCODE, Instruction::MSTORE8, Instruction::MSTORE, Instruction::MLOAD, Instruction::SHA3})
+		for (auto const& c: {Instruction::SSTORE, Instruction::SLOAD, Instruction::CALL, Instruction::CREATE, Instruction::CALLCODE, Instruction::DELEGATECALL, Instruction::MSTORE8, Instruction::MSTORE, Instruction::MLOAD, Instruction::SHA3})
 			if (!!counts[(byte)c].first)
 				cout << "  " << instructionInfo(c).name << " x " << counts[(byte)c].first << " (" << counts[(byte)c].second << " gas)" << endl;
 	}

--- a/evmjit/libevmjit/GasMeter.cpp
+++ b/evmjit/libevmjit/GasMeter.cpp
@@ -139,6 +139,7 @@ int64_t getStepCost(Instruction inst)
 
 	case Instruction::CALL:
 	case Instruction::CALLCODE:
+	case Instruction::DELEGATECALL:
 		return c_callGas;
 
 	case Instruction::CREATE:

--- a/evmjit/libevmjit/Instruction.h
+++ b/evmjit/libevmjit/Instruction.h
@@ -153,6 +153,7 @@ enum class Instruction: uint8_t
 	CALL,				///< message-call into an account
 	CALLCODE,			///< message-call with another account's code only
 	RETURN,				///< halt execution returning output data
+	DELEGATECALL,		///< like CALLCODE but keeps caller's value and sender (only from homestead on)
 	SUICIDE = 0xff		///< halt execution and register account for later deletion
 };
 

--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -79,20 +79,12 @@ StringHashMap Ethash::jsInfo(BlockHeader const& _bi) const
 	return { { "nonce", toJS(nonce(_bi)) }, { "seedHash", toJS(seedHash(_bi)) }, { "mixHash", toJS(mixHash(_bi)) }, { "boundary", toJS(boundary(_bi)) }, { "difficulty", toJS(_bi.difficulty()) } };
 }
 
-EVMSchedule Ethash::evmSchedule(EnvInfo const& _envInfo) const
+EVMSchedule const& Ethash::evmSchedule(EnvInfo const& _envInfo) const
 {
-	EVMSchedule ret;
 	if (_envInfo.number() >= chainParams().u256Param("frontierCompatibilityModeLimit"))
-	{
-		ret.exceptionalFailedCodeDeposit = ret.haveDelegateCall = true;
-		ret.txCreateGas = 53000;
-	}
+		return HomesteadSchedule;
 	else
-	{
-		ret.exceptionalFailedCodeDeposit = ret.haveDelegateCall = false;
-		ret.txCreateGas = 21000;
-	}
-	return ret;
+		return FrontierSchedule;
 }
 
 void Ethash::verify(Strictness _s, BlockHeader const& _bi, BlockHeader const& _parent, bytesConstRef _block) const

--- a/libethashseal/Ethash.h
+++ b/libethashseal/Ethash.h
@@ -69,7 +69,7 @@ public:
 	u256 calculateDifficulty(BlockHeader const& _bi, BlockHeader const& _parent) const;
 	u256 childGasLimit(BlockHeader const& _bi, u256 const& _gasFloorTarget = Invalid256) const;
 
-	virtual EVMSchedule evmSchedule(EnvInfo const&) const override;
+	virtual EVMSchedule const& evmSchedule(EnvInfo const&) const override;
 
 	void manuallySetWork(BlockHeader const& _work) { m_sealing = _work; }
 	void manuallySubmitWork(h256 const& _mixHash, Nonce _nonce);

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -75,7 +75,7 @@ public:
 	ChainOperationParams const& chainParams() const { return m_params; }
 	void setChainParams(ChainOperationParams const& _params) { m_params = _params; }
 	SealEngineFace* withChainParams(ChainOperationParams const& _params) { setChainParams(_params); return this; }
-	virtual EVMSchedule evmSchedule(EnvInfo const&) const { return m_params.evmSchedule; }
+	virtual EVMSchedule const& evmSchedule(EnvInfo const&) const { return m_params.evmSchedule; }
 
 	virtual bool isPrecompiled(Address const& _a) const { return m_params.precompiled.count(_a); }
 	virtual bigint costOfPrecompiled(Address const& _a, bytesConstRef _in) const { return m_params.precompiled.at(_a).cost(_in); }

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -147,7 +147,7 @@ public:
 	virtual BlockHeader pendingInfo() const override;
 	virtual BlockDetails pendingDetails() const override;
 
-	EVMSchedule evmSchedule() const override { return sealEngine()->evmSchedule(EnvInfo(pendingInfo())); }
+	virtual EVMSchedule evmSchedule() const override { return sealEngine()->evmSchedule(EnvInfo(pendingInfo())); }
 
 	virtual ImportResult injectTransaction(bytes const& _rlp, IfDropped _id = IfDropped::Ignore) override { prepareForTransaction(); return m_tq.import(_rlp, _id); }
 	virtual ImportResult injectBlock(bytes const& _block) override;

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -33,12 +33,7 @@ namespace
 static unsigned const c_depthLimit = 1024;
 
 /// Upper bound of stack space needed by single CALL/CREATE execution. Set experimentally.
-static size_t const c_singleExecutionStackSize =
-#ifdef NDEBUG
-	14 * 1024;
-#else
-	17 * 1024;
-#endif
+static size_t const c_singleExecutionStackSize = 6 * 1024;
 
 /// Standard thread stack size.
 static size_t const c_defaultStackSize =
@@ -47,7 +42,7 @@ static size_t const c_defaultStackSize =
 #elif defined(_WIN32)
 	16 * 1024 * 1024;
 #else
-	      512 * 1024; // OSX and other OSs
+	512 * 1024; // OSX and other OSs
 #endif
 
 /// Stack overhead prior to allocation.

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -35,9 +35,9 @@ static unsigned const c_depthLimit = 1024;
 /// Upper bound of stack space needed by single CALL/CREATE execution. Set experimentally.
 static size_t const c_singleExecutionStackSize =
 #ifdef NDEBUG
-	10 * 1024;
+	14 * 1024;
 #else
-	16 * 1024;
+	17 * 1024;
 #endif
 
 /// Standard thread stack size.

--- a/libethereum/ExtVM.h
+++ b/libethereum/ExtVM.h
@@ -92,7 +92,7 @@ public:
 	}
 
 	/// Return the EVM gas-price schedule for this execution context.
-	EVMSchedule evmSchedule() const override final { return m_sealEngine->evmSchedule(envInfo()); }
+	virtual EVMSchedule const& evmSchedule() const override final { return m_sealEngine->evmSchedule(envInfo()); }
 
 	State& state() const { return m_s; }
 

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -278,7 +278,7 @@ public:
 	EnvInfo const& envInfo() const { return m_envInfo; }
 
 	/// Return the EVM gas-price schedule for this execution context.
-	virtual EVMSchedule evmSchedule() const { return EVMSchedule(); }
+	virtual EVMSchedule const& evmSchedule() const { return DefaultSchedule; }
 
 private:
 	EnvInfo const& m_envInfo;

--- a/libevm/JitEnv.cpp
+++ b/libevm/JitEnv.cpp
@@ -62,7 +62,7 @@ extern "C"
 
 	EXPORT bool env_call(ExtVMFace* _env, int64_t* io_gas, int64_t _callGas, h256* _receiveAddress, i256* _value, byte* _inBeg, uint64_t _inSize, byte* _outBeg, uint64_t _outSize, h256* _codeAddress)
 	{
-		EVMSchedule schedule = _env->evmSchedule(); // TODO: maybe memoise?
+		EVMSchedule const& schedule = _env->evmSchedule();
 
 		CallParameters params;
 

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -268,366 +268,9 @@ bytesConstRef VM::execImpl(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp)
 
 		switch (inst)
 		{
-		case Instruction::ADD:
-			//pops two items and pushes S[-1] + S[-2] mod 2^256.
-			m_stack[m_stack.size() - 2] += m_stack.back();
-			m_stack.pop_back();
-			break;
-		case Instruction::MUL:
-			//pops two items and pushes S[-1] * S[-2] mod 2^256.
-			m_stack[m_stack.size() - 2] *= m_stack.back();
-			m_stack.pop_back();
-			break;
-		case Instruction::SUB:
-			m_stack[m_stack.size() - 2] = m_stack.back() - m_stack[m_stack.size() - 2];
-			m_stack.pop_back();
-			break;
-		case Instruction::DIV:
-			m_stack[m_stack.size() - 2] = m_stack[m_stack.size() - 2] ? divWorkaround(m_stack.back(), m_stack[m_stack.size() - 2]) : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::SDIV:
-			m_stack[m_stack.size() - 2] = m_stack[m_stack.size() - 2] ? s2u(divWorkaround(u2s(m_stack.back()), u2s(m_stack[m_stack.size() - 2]))) : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::MOD:
-			m_stack[m_stack.size() - 2] = m_stack[m_stack.size() - 2] ? modWorkaround(m_stack.back(), m_stack[m_stack.size() - 2]) : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::SMOD:
-			m_stack[m_stack.size() - 2] = m_stack[m_stack.size() - 2] ? s2u(modWorkaround(u2s(m_stack.back()), u2s(m_stack[m_stack.size() - 2]))) : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::EXP:
-		{
-			auto base = m_stack.back();
-			auto expon = m_stack[m_stack.size() - 2];
-			m_stack.pop_back();
-			m_stack.back() = (u256)boost::multiprecision::powm((bigint)base, (bigint)expon, bigint(1) << 256);
-			break;
-		}
-		case Instruction::NOT:
-			m_stack.back() = ~m_stack.back();
-			break;
-		case Instruction::LT:
-			m_stack[m_stack.size() - 2] = m_stack.back() < m_stack[m_stack.size() - 2] ? 1 : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::GT:
-			m_stack[m_stack.size() - 2] = m_stack.back() > m_stack[m_stack.size() - 2] ? 1 : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::SLT:
-			m_stack[m_stack.size() - 2] = u2s(m_stack.back()) < u2s(m_stack[m_stack.size() - 2]) ? 1 : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::SGT:
-			m_stack[m_stack.size() - 2] = u2s(m_stack.back()) > u2s(m_stack[m_stack.size() - 2]) ? 1 : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::EQ:
-			m_stack[m_stack.size() - 2] = m_stack.back() == m_stack[m_stack.size() - 2] ? 1 : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::ISZERO:
-			m_stack.back() = m_stack.back() ? 0 : 1;
-			break;
-		case Instruction::AND:
-			m_stack[m_stack.size() - 2] = m_stack.back() & m_stack[m_stack.size() - 2];
-			m_stack.pop_back();
-			break;
-		case Instruction::OR:
-			m_stack[m_stack.size() - 2] = m_stack.back() | m_stack[m_stack.size() - 2];
-			m_stack.pop_back();
-			break;
-		case Instruction::XOR:
-			m_stack[m_stack.size() - 2] = m_stack.back() ^ m_stack[m_stack.size() - 2];
-			m_stack.pop_back();
-			break;
-		case Instruction::BYTE:
-			m_stack[m_stack.size() - 2] = m_stack.back() < 32 ? (m_stack[m_stack.size() - 2] >> (unsigned)(8 * (31 - m_stack.back()))) & 0xff : 0;
-			m_stack.pop_back();
-			break;
-		case Instruction::ADDMOD:
-			m_stack[m_stack.size() - 3] = m_stack[m_stack.size() - 3] ? u256((bigint(m_stack.back()) + bigint(m_stack[m_stack.size() - 2])) % m_stack[m_stack.size() - 3]) : 0;
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		case Instruction::MULMOD:
-			m_stack[m_stack.size() - 3] = m_stack[m_stack.size() - 3] ? u256((bigint(m_stack.back()) * bigint(m_stack[m_stack.size() - 2])) % m_stack[m_stack.size() - 3]) : 0;
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		case Instruction::SIGNEXTEND:
-			if (m_stack.back() < 31)
-			{
-				auto testBit = static_cast<unsigned>(m_stack.back()) * 8 + 7;
-				u256& number = m_stack[m_stack.size() - 2];
-				u256 mask = ((u256(1) << testBit) - 1);
-				if (boost::multiprecision::bit_test(number, testBit))
-					number |= ~mask;
-				else
-					number &= mask;
-			}
-			m_stack.pop_back();
-			break;
-		case Instruction::SHA3:
-		{
-			unsigned inOff = (unsigned)m_stack.back();
-			m_stack.pop_back();
-			unsigned inSize = (unsigned)m_stack.back();
-			m_stack.pop_back();
-			m_stack.push_back(sha3(bytesConstRef(m_temp.data() + inOff, inSize)));
-			break;
-		}
-		case Instruction::ADDRESS:
-			m_stack.push_back(fromAddress(_ext.myAddress));
-			break;
-		case Instruction::ORIGIN:
-			m_stack.push_back(fromAddress(_ext.origin));
-			break;
-		case Instruction::BALANCE:
-		{
-			m_stack.back() = _ext.balance(asAddress(m_stack.back()));
-			break;
-		}
-		case Instruction::CALLER:
-			m_stack.push_back(fromAddress(_ext.caller));
-			break;
-		case Instruction::CALLVALUE:
-			m_stack.push_back(_ext.value);
-			break;
-		case Instruction::CALLDATALOAD:
-		{
-			if ((bigint)m_stack.back() + 31 < _ext.data.size())
-				m_stack.back() = (u256)*(h256 const*)(_ext.data.data() + (size_t)m_stack.back());
-			else if ((bigint)m_stack.back() >= _ext.data.size())
-				m_stack.back() = u256();
-			else
-			{
-				h256 r;
-				for (uint64_t i = (unsigned)m_stack.back(), e = (unsigned)m_stack.back() + (uint64_t)32, j = 0; i < e; ++i, ++j)
-					r[j] = i < _ext.data.size() ? _ext.data[i] : 0;
-				m_stack.back() = (u256)r;
-			}
-			break;
-		}
-		case Instruction::CALLDATASIZE:
-			m_stack.push_back(_ext.data.size());
-			break;
-		case Instruction::CODESIZE:
-			m_stack.push_back(_ext.code.size());
-			break;
-		case Instruction::EXTCODESIZE:
-			m_stack.back() = _ext.codeAt(asAddress(m_stack.back())).size();
-			break;
-		case Instruction::CALLDATACOPY:
-			copyDataToMemory(_ext.data);
-			break;
-		case Instruction::CODECOPY:
-			copyDataToMemory(&_ext.code);
-			break;
-		case Instruction::EXTCODECOPY:
-		{
-			auto a = asAddress(m_stack.back());
-			m_stack.pop_back();
-			copyDataToMemory(&_ext.codeAt(a));
-			break;
-		}
-		case Instruction::GASPRICE:
-			m_stack.push_back(_ext.gasPrice);
-			break;
-		case Instruction::BLOCKHASH:
-			m_stack.back() = (u256)_ext.blockHash(m_stack.back());
-			break;
-		case Instruction::COINBASE:
-			m_stack.push_back((u160)_ext.envInfo().author());
-			break;
-		case Instruction::TIMESTAMP:
-			m_stack.push_back(_ext.envInfo().timestamp());
-			break;
-		case Instruction::NUMBER:
-			m_stack.push_back(_ext.envInfo().number());
-			break;
-		case Instruction::DIFFICULTY:
-			m_stack.push_back(_ext.envInfo().difficulty());
-			break;
-		case Instruction::GASLIMIT:
-			m_stack.push_back(_ext.envInfo().gasLimit());
-			break;
-		case Instruction::PUSH1:
-		case Instruction::PUSH2:
-		case Instruction::PUSH3:
-		case Instruction::PUSH4:
-		case Instruction::PUSH5:
-		case Instruction::PUSH6:
-		case Instruction::PUSH7:
-		case Instruction::PUSH8:
-		case Instruction::PUSH9:
-		case Instruction::PUSH10:
-		case Instruction::PUSH11:
-		case Instruction::PUSH12:
-		case Instruction::PUSH13:
-		case Instruction::PUSH14:
-		case Instruction::PUSH15:
-		case Instruction::PUSH16:
-		case Instruction::PUSH17:
-		case Instruction::PUSH18:
-		case Instruction::PUSH19:
-		case Instruction::PUSH20:
-		case Instruction::PUSH21:
-		case Instruction::PUSH22:
-		case Instruction::PUSH23:
-		case Instruction::PUSH24:
-		case Instruction::PUSH25:
-		case Instruction::PUSH26:
-		case Instruction::PUSH27:
-		case Instruction::PUSH28:
-		case Instruction::PUSH29:
-		case Instruction::PUSH30:
-		case Instruction::PUSH31:
-		case Instruction::PUSH32:
-		{
-			int i = (int)inst - (int)Instruction::PUSH1 + 1;
-			nextPC = m_curPC + 1;
-			m_stack.push_back(0);
-			for (; i--; nextPC++)
-				m_stack.back() = (m_stack.back() << 8) | _ext.getCode(nextPC);
-			break;
-		}
-		case Instruction::POP:
-			m_stack.pop_back();
-			break;
-		case Instruction::DUP1:
-		case Instruction::DUP2:
-		case Instruction::DUP3:
-		case Instruction::DUP4:
-		case Instruction::DUP5:
-		case Instruction::DUP6:
-		case Instruction::DUP7:
-		case Instruction::DUP8:
-		case Instruction::DUP9:
-		case Instruction::DUP10:
-		case Instruction::DUP11:
-		case Instruction::DUP12:
-		case Instruction::DUP13:
-		case Instruction::DUP14:
-		case Instruction::DUP15:
-		case Instruction::DUP16:
-		{
-			auto n = 1 + (unsigned)inst - (unsigned)Instruction::DUP1;
-			m_stack.push_back(m_stack[m_stack.size() - n]);
-			break;
-		}
-		case Instruction::SWAP1:
-		case Instruction::SWAP2:
-		case Instruction::SWAP3:
-		case Instruction::SWAP4:
-		case Instruction::SWAP5:
-		case Instruction::SWAP6:
-		case Instruction::SWAP7:
-		case Instruction::SWAP8:
-		case Instruction::SWAP9:
-		case Instruction::SWAP10:
-		case Instruction::SWAP11:
-		case Instruction::SWAP12:
-		case Instruction::SWAP13:
-		case Instruction::SWAP14:
-		case Instruction::SWAP15:
-		case Instruction::SWAP16:
-		{
-			auto n = (unsigned)inst - (unsigned)Instruction::SWAP1 + 2;
-			auto d = m_stack.back();
-			m_stack.back() = m_stack[m_stack.size() - n];
-			m_stack[m_stack.size() - n] = d;
-			break;
-		}
-		case Instruction::MLOAD:
-		{
-			m_stack.back() = (u256)*(h256 const*)(m_temp.data() + (unsigned)m_stack.back());
-			break;
-		}
-		case Instruction::MSTORE:
-		{
-			*(h256*)&m_temp[(unsigned)m_stack.back()] = (h256)m_stack[m_stack.size() - 2];
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		}
-		case Instruction::MSTORE8:
-		{
-			m_temp[(unsigned)m_stack.back()] = (byte)(m_stack[m_stack.size() - 2] & 0xff);
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		}
-		case Instruction::SLOAD:
-			m_stack.back() = _ext.store(m_stack.back());
-			break;
-		case Instruction::SSTORE:
-			_ext.setStore(m_stack.back(), m_stack[m_stack.size() - 2]);
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		case Instruction::JUMP:
-			nextPC = verifyJumpDest(m_stack.back(), m_jumpDests);
-			m_stack.pop_back();
-			break;
-		case Instruction::JUMPI:
-			if (m_stack[m_stack.size() - 2])
-				nextPC = verifyJumpDest(m_stack.back(), m_jumpDests);
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		case Instruction::PC:
-			m_stack.push_back(m_curPC);
-			break;
-		case Instruction::MSIZE:
-			m_stack.push_back(m_temp.size());
-			break;
-		case Instruction::GAS:
-			m_stack.push_back(io_gas);
-			break;
-		case Instruction::JUMPDEST:
-			break;
-		case Instruction::LOG0:
-			_ext.log({}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		case Instruction::LOG1:
-			_ext.log({m_stack[m_stack.size() - 3]}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		case Instruction::LOG2:
-			_ext.log({m_stack[m_stack.size() - 3], m_stack[m_stack.size() - 4]}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		case Instruction::LOG3:
-			_ext.log({m_stack[m_stack.size() - 3], m_stack[m_stack.size() - 4], m_stack[m_stack.size() - 5]}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
-		case Instruction::LOG4:
-			_ext.log({m_stack[m_stack.size() - 3], m_stack[m_stack.size() - 4], m_stack[m_stack.size() - 5], m_stack[m_stack.size() - 6]}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			m_stack.pop_back();
-			break;
 		case Instruction::CREATE:
 		{
-			auto endowment = m_stack.back();
+			auto const& endowment = m_stack.back();
 			m_stack.pop_back();
 			unsigned initOff = (unsigned)m_stack.back();
 			m_stack.pop_back();
@@ -701,12 +344,380 @@ bytesConstRef VM::execImpl(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp)
 		{
 			Address dest = asAddress(m_stack.back());
 			_ext.suicide(dest);
-			// ...follow through to...
+			return bytesConstRef();
 		}
 		case Instruction::STOP:
 			return bytesConstRef();
+		default:
+			nextPC = execOrdinaryOpcode(inst, io_gas, _ext);
 		}
 	}
 
 	return bytesConstRef();
+}
+
+uint64_t VM::execOrdinaryOpcode(Instruction _inst, u256 &io_gas, ExtVMFace& _ext)
+{
+	uint64_t nextPC = m_curPC + 1;
+	switch (_inst)
+	{
+	case Instruction::ADD:
+		//pops two items and pushes S[-1] + S[-2] mod 2^256.
+		m_stack[m_stack.size() - 2] += m_stack.back();
+		m_stack.pop_back();
+		break;
+	case Instruction::MUL:
+		//pops two items and pushes S[-1] * S[-2] mod 2^256.
+		m_stack[m_stack.size() - 2] *= m_stack.back();
+		m_stack.pop_back();
+		break;
+	case Instruction::SUB:
+		m_stack[m_stack.size() - 2] = m_stack.back() - m_stack[m_stack.size() - 2];
+		m_stack.pop_back();
+		break;
+	case Instruction::DIV:
+		m_stack[m_stack.size() - 2] = m_stack[m_stack.size() - 2] ? divWorkaround(m_stack.back(), m_stack[m_stack.size() - 2]) : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::SDIV:
+		m_stack[m_stack.size() - 2] = m_stack[m_stack.size() - 2] ? s2u(divWorkaround(u2s(m_stack.back()), u2s(m_stack[m_stack.size() - 2]))) : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::MOD:
+		m_stack[m_stack.size() - 2] = m_stack[m_stack.size() - 2] ? modWorkaround(m_stack.back(), m_stack[m_stack.size() - 2]) : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::SMOD:
+		m_stack[m_stack.size() - 2] = m_stack[m_stack.size() - 2] ? s2u(modWorkaround(u2s(m_stack.back()), u2s(m_stack[m_stack.size() - 2]))) : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::EXP:
+	{
+		auto base = m_stack.back();
+		auto expon = m_stack[m_stack.size() - 2];
+		m_stack.pop_back();
+		m_stack.back() = (u256)boost::multiprecision::powm((bigint)base, (bigint)expon, bigint(1) << 256);
+		break;
+	}
+	case Instruction::NOT:
+		m_stack.back() = ~m_stack.back();
+		break;
+	case Instruction::LT:
+		m_stack[m_stack.size() - 2] = m_stack.back() < m_stack[m_stack.size() - 2] ? 1 : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::GT:
+		m_stack[m_stack.size() - 2] = m_stack.back() > m_stack[m_stack.size() - 2] ? 1 : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::SLT:
+		m_stack[m_stack.size() - 2] = u2s(m_stack.back()) < u2s(m_stack[m_stack.size() - 2]) ? 1 : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::SGT:
+		m_stack[m_stack.size() - 2] = u2s(m_stack.back()) > u2s(m_stack[m_stack.size() - 2]) ? 1 : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::EQ:
+		m_stack[m_stack.size() - 2] = m_stack.back() == m_stack[m_stack.size() - 2] ? 1 : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::ISZERO:
+		m_stack.back() = m_stack.back() ? 0 : 1;
+		break;
+	case Instruction::AND:
+		m_stack[m_stack.size() - 2] = m_stack.back() & m_stack[m_stack.size() - 2];
+		m_stack.pop_back();
+		break;
+	case Instruction::OR:
+		m_stack[m_stack.size() - 2] = m_stack.back() | m_stack[m_stack.size() - 2];
+		m_stack.pop_back();
+		break;
+	case Instruction::XOR:
+		m_stack[m_stack.size() - 2] = m_stack.back() ^ m_stack[m_stack.size() - 2];
+		m_stack.pop_back();
+		break;
+	case Instruction::BYTE:
+		m_stack[m_stack.size() - 2] = m_stack.back() < 32 ? (m_stack[m_stack.size() - 2] >> (unsigned)(8 * (31 - m_stack.back()))) & 0xff : 0;
+		m_stack.pop_back();
+		break;
+	case Instruction::ADDMOD:
+		m_stack[m_stack.size() - 3] = m_stack[m_stack.size() - 3] ? u256((bigint(m_stack.back()) + bigint(m_stack[m_stack.size() - 2])) % m_stack[m_stack.size() - 3]) : 0;
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	case Instruction::MULMOD:
+		m_stack[m_stack.size() - 3] = m_stack[m_stack.size() - 3] ? u256((bigint(m_stack.back()) * bigint(m_stack[m_stack.size() - 2])) % m_stack[m_stack.size() - 3]) : 0;
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	case Instruction::SIGNEXTEND:
+		if (m_stack.back() < 31)
+		{
+			auto testBit = static_cast<unsigned>(m_stack.back()) * 8 + 7;
+			u256& number = m_stack[m_stack.size() - 2];
+			u256 mask = ((u256(1) << testBit) - 1);
+			if (boost::multiprecision::bit_test(number, testBit))
+				number |= ~mask;
+			else
+				number &= mask;
+		}
+		m_stack.pop_back();
+		break;
+	case Instruction::SHA3:
+	{
+		unsigned inOff = (unsigned)m_stack.back();
+		m_stack.pop_back();
+		unsigned inSize = (unsigned)m_stack.back();
+		m_stack.pop_back();
+		m_stack.push_back(sha3(bytesConstRef(m_temp.data() + inOff, inSize)));
+		break;
+	}
+	case Instruction::ADDRESS:
+		m_stack.push_back(fromAddress(_ext.myAddress));
+		break;
+	case Instruction::ORIGIN:
+		m_stack.push_back(fromAddress(_ext.origin));
+		break;
+	case Instruction::BALANCE:
+	{
+		m_stack.back() = _ext.balance(asAddress(m_stack.back()));
+		break;
+	}
+	case Instruction::CALLER:
+		m_stack.push_back(fromAddress(_ext.caller));
+		break;
+	case Instruction::CALLVALUE:
+		m_stack.push_back(_ext.value);
+		break;
+	case Instruction::CALLDATALOAD:
+	{
+		if ((bigint)m_stack.back() + 31 < _ext.data.size())
+			m_stack.back() = (u256)*(h256 const*)(_ext.data.data() + (size_t)m_stack.back());
+		else if ((bigint)m_stack.back() >= _ext.data.size())
+			m_stack.back() = u256();
+		else
+		{
+			h256 r;
+			for (uint64_t i = (unsigned)m_stack.back(), e = (unsigned)m_stack.back() + (uint64_t)32, j = 0; i < e; ++i, ++j)
+				r[j] = i < _ext.data.size() ? _ext.data[i] : 0;
+			m_stack.back() = (u256)r;
+		}
+		break;
+	}
+	case Instruction::CALLDATASIZE:
+		m_stack.push_back(_ext.data.size());
+		break;
+	case Instruction::CODESIZE:
+		m_stack.push_back(_ext.code.size());
+		break;
+	case Instruction::EXTCODESIZE:
+		m_stack.back() = _ext.codeAt(asAddress(m_stack.back())).size();
+		break;
+	case Instruction::CALLDATACOPY:
+		copyDataToMemory(_ext.data);
+		break;
+	case Instruction::CODECOPY:
+		copyDataToMemory(&_ext.code);
+		break;
+	case Instruction::EXTCODECOPY:
+	{
+		auto a = asAddress(m_stack.back());
+		m_stack.pop_back();
+		copyDataToMemory(&_ext.codeAt(a));
+		break;
+	}
+	case Instruction::GASPRICE:
+		m_stack.push_back(_ext.gasPrice);
+		break;
+	case Instruction::BLOCKHASH:
+		m_stack.back() = (u256)_ext.blockHash(m_stack.back());
+		break;
+	case Instruction::COINBASE:
+		m_stack.push_back((u160)_ext.envInfo().author());
+		break;
+	case Instruction::TIMESTAMP:
+		m_stack.push_back(_ext.envInfo().timestamp());
+		break;
+	case Instruction::NUMBER:
+		m_stack.push_back(_ext.envInfo().number());
+		break;
+	case Instruction::DIFFICULTY:
+		m_stack.push_back(_ext.envInfo().difficulty());
+		break;
+	case Instruction::GASLIMIT:
+		m_stack.push_back(_ext.envInfo().gasLimit());
+		break;
+	case Instruction::POP:
+		m_stack.pop_back();
+		break;
+	case Instruction::PUSH1:
+	case Instruction::PUSH2:
+	case Instruction::PUSH3:
+	case Instruction::PUSH4:
+	case Instruction::PUSH5:
+	case Instruction::PUSH6:
+	case Instruction::PUSH7:
+	case Instruction::PUSH8:
+	case Instruction::PUSH9:
+	case Instruction::PUSH10:
+	case Instruction::PUSH11:
+	case Instruction::PUSH12:
+	case Instruction::PUSH13:
+	case Instruction::PUSH14:
+	case Instruction::PUSH15:
+	case Instruction::PUSH16:
+	case Instruction::PUSH17:
+	case Instruction::PUSH18:
+	case Instruction::PUSH19:
+	case Instruction::PUSH20:
+	case Instruction::PUSH21:
+	case Instruction::PUSH22:
+	case Instruction::PUSH23:
+	case Instruction::PUSH24:
+	case Instruction::PUSH25:
+	case Instruction::PUSH26:
+	case Instruction::PUSH27:
+	case Instruction::PUSH28:
+	case Instruction::PUSH29:
+	case Instruction::PUSH30:
+	case Instruction::PUSH31:
+	case Instruction::PUSH32:
+	{
+		int i = (int)_inst - (int)Instruction::PUSH1 + 1;
+		nextPC = m_curPC + 1;
+		m_stack.push_back(0);
+		for (; i--; nextPC++)
+			m_stack.back() = (m_stack.back() << 8) | _ext.getCode(nextPC);
+		break;
+	}
+	case Instruction::JUMP:
+		nextPC = verifyJumpDest(m_stack.back(), m_jumpDests);
+		m_stack.pop_back();
+		break;
+	case Instruction::JUMPI:
+		if (m_stack[m_stack.size() - 2])
+			nextPC = verifyJumpDest(m_stack.back(), m_jumpDests);
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	case Instruction::DUP1:
+	case Instruction::DUP2:
+	case Instruction::DUP3:
+	case Instruction::DUP4:
+	case Instruction::DUP5:
+	case Instruction::DUP6:
+	case Instruction::DUP7:
+	case Instruction::DUP8:
+	case Instruction::DUP9:
+	case Instruction::DUP10:
+	case Instruction::DUP11:
+	case Instruction::DUP12:
+	case Instruction::DUP13:
+	case Instruction::DUP14:
+	case Instruction::DUP15:
+	case Instruction::DUP16:
+	{
+		auto n = 1 + (unsigned)_inst - (unsigned)Instruction::DUP1;
+		m_stack.push_back(m_stack[m_stack.size() - n]);
+		break;
+	}
+	case Instruction::SWAP1:
+	case Instruction::SWAP2:
+	case Instruction::SWAP3:
+	case Instruction::SWAP4:
+	case Instruction::SWAP5:
+	case Instruction::SWAP6:
+	case Instruction::SWAP7:
+	case Instruction::SWAP8:
+	case Instruction::SWAP9:
+	case Instruction::SWAP10:
+	case Instruction::SWAP11:
+	case Instruction::SWAP12:
+	case Instruction::SWAP13:
+	case Instruction::SWAP14:
+	case Instruction::SWAP15:
+	case Instruction::SWAP16:
+	{
+		auto n = (unsigned)_inst - (unsigned)Instruction::SWAP1 + 2;
+		auto d = m_stack.back();
+		m_stack.back() = m_stack[m_stack.size() - n];
+		m_stack[m_stack.size() - n] = d;
+		break;
+	}
+	case Instruction::MLOAD:
+	{
+		m_stack.back() = (u256)*(h256 const*)(m_temp.data() + (unsigned)m_stack.back());
+		break;
+	}
+	case Instruction::MSTORE:
+	{
+		*(h256*)&m_temp[(unsigned)m_stack.back()] = (h256)m_stack[m_stack.size() - 2];
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	}
+	case Instruction::MSTORE8:
+	{
+		m_temp[(unsigned)m_stack.back()] = (byte)(m_stack[m_stack.size() - 2] & 0xff);
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	}
+	case Instruction::SLOAD:
+		m_stack.back() = _ext.store(m_stack.back());
+		break;
+	case Instruction::SSTORE:
+		_ext.setStore(m_stack.back(), m_stack[m_stack.size() - 2]);
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	case Instruction::PC:
+		m_stack.push_back(m_curPC);
+		break;
+	case Instruction::MSIZE:
+		m_stack.push_back(m_temp.size());
+		break;
+	case Instruction::GAS:
+		m_stack.push_back(io_gas);
+		break;
+	case Instruction::JUMPDEST:
+		break;
+	case Instruction::LOG0:
+		_ext.log({}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	case Instruction::LOG1:
+		_ext.log({m_stack[m_stack.size() - 3]}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	case Instruction::LOG2:
+		_ext.log({m_stack[m_stack.size() - 3], m_stack[m_stack.size() - 4]}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	case Instruction::LOG3:
+		_ext.log({m_stack[m_stack.size() - 3], m_stack[m_stack.size() - 4], m_stack[m_stack.size() - 5]}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	case Instruction::LOG4:
+		_ext.log({m_stack[m_stack.size() - 3], m_stack[m_stack.size() - 4], m_stack[m_stack.size() - 5], m_stack[m_stack.size() - 6]}, bytesConstRef(m_temp.data() + (unsigned)m_stack[m_stack.size() - 1], (unsigned)m_stack[m_stack.size() - 2]));
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		m_stack.pop_back();
+		break;
+	}
+	return nextPC;
 }

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -718,6 +718,14 @@ uint64_t VM::execOrdinaryOpcode(Instruction _inst, u256 &io_gas, ExtVMFace& _ext
 		m_stack.pop_back();
 		m_stack.pop_back();
 		break;
+	case Instruction::CREATE:
+	case Instruction::CALL:
+	case Instruction::CALLCODE:
+	case Instruction::DELEGATECALL:
+	case Instruction::RETURN:
+	case Instruction::SUICIDE:
+	case Instruction::STOP:
+		break; // These are handled above
 	}
 	return nextPC;
 }

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -71,7 +71,7 @@ private:
 	u256s m_stack;
 	std::vector<uint64_t> m_jumpDests;
 	std::function<void()> m_onFail;
-	EVMSchedule m_schedule;
+	EVMSchedule const* m_schedule = nullptr;
 };
 
 }

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -64,6 +64,7 @@ private:
 	void requireMem(unsigned _n) { if (m_temp.size() < _n) { m_temp.resize(_n); } }
 	static uint64_t verifyJumpDest(u256 const& _dest, std::vector<uint64_t> const& _validDests);
 	void copyDataToMemory(bytesConstRef _data);
+	uint64_t execOrdinaryOpcode(Instruction _inst, u256& io_gas, ExtVMFace& _ext);
 
 	uint64_t m_curPC = 0;
 	uint64_t m_steps = 0;

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -62,6 +62,8 @@ private:
 	void checkRequirements(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp, Instruction _inst);
 	void require(u256 _n, u256 _d);
 	void requireMem(unsigned _n) { if (m_temp.size() < _n) { m_temp.resize(_n); } }
+	static uint64_t verifyJumpDest(u256 const& _dest, std::vector<uint64_t> const& _validDests);
+	void copyDataToMemory(bytesConstRef _data);
 
 	uint64_t m_curPC = 0;
 	uint64_t m_steps = 0;

--- a/libevmcore/EVMSchedule.h
+++ b/libevmcore/EVMSchedule.h
@@ -65,6 +65,7 @@ struct EVMSchedule
 	u256 copyGas = 3;
 };
 
+static const EVMSchedule DefaultSchedule = EVMSchedule();
 static const EVMSchedule FrontierSchedule = EVMSchedule(false, false, 21000);
 static const EVMSchedule HomesteadSchedule = EVMSchedule(true, true, 53000);
 


### PR DESCRIPTION
This includes three changes:
1. Return EVMSchedule by reference in internal functions
2. Allocate CallParams on the heap
3. Move most of the opcode implementation to its own function

Surprisingly, the third point provided the largest boost, as apparently, memory for temporaries is allocated on the stack and not re-used between switch cases or scopes.
