### PR TITLE
Fix calculateDifficulty from double maxmin

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -190,11 +190,14 @@ u256 Ethash::calculateDifficulty(BlockHeader const& _bi, BlockHeader const& _par
 	else
 		// Homestead-era difficulty adjustment
 		target = _parent.difficulty() + _parent.difficulty() / 2048 * max<bigint>(1 - (bigint(_bi.timestamp()) - _parent.timestamp()) / 10, -99);
-	u256 o = (u256)max<bigint>(minimumDifficulty, target);
+
+	bigint o = target;
 	unsigned periodCount = unsigned(_parent.number() + 1) / c_expDiffPeriod;
 	if (periodCount > 1)
-		o = max<u256>(minimumDifficulty, o + (u256(1) << (periodCount - 2)));	// latter will eventually become huge, so ensure it's a bigint.
-	return o;
+		o += (u256(1) << (periodCount - 2));	// latter will eventually become huge, so ensure it's a bigint.
+
+	o = max<bigint>(minimumDifficulty, o);
+	return (u256)o;
 }
 
 void Ethash::populateFromParent(BlockHeader& _bi, BlockHeader const& _parent) const

--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -196,7 +196,7 @@ u256 Ethash::calculateDifficulty(BlockHeader const& _bi, BlockHeader const& _par
 	if (periodCount > 1)
 		o += (u256(1) << (periodCount - 2));	// latter will eventually become huge, so ensure it's a bigint.
 
-	o = max<bigint>(minimumDifficulty, o);
+	o = max<u256>(minimumDifficulty, (u256)o);
 	return (u256)o;
 }
 


### PR DESCRIPTION
this expression
result difficulty = max ( mindifficulty, calculatedDifficulty)
should be done at the end of all calculations right?
in line 199
o = max<u256>(minimumDifficulty, o + (u256(1) << (periodCount - 2)));
it looks like this
result difficulty = max ( mindifficulty, calculatedDifficulty)
where calculatedDifficulty = max (mindifficulty, calculatedDifficulty2) + x
So when calculatedDifficulty2 < minDifficulty instead of being
resultDifficulty = max ( mindifficulty, calculatedDifficulty2 + x)
it is
resultDifficulty = max ( mindifficulty, mindifficulty + x)

Martin is using  fixed example in his JS client.
