### PR TITLE
Fix Boost 1.60 build

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -116,7 +116,12 @@ void Ethash::verify(Strictness _s, BlockHeader const& _bi, BlockHeader const& _p
 		if (gasLimit < chainParams().u256Param("minGasLimit") ||
 			gasLimit <= parentGasLimit - parentGasLimit / chainParams().u256Param("gasLimitBoundDivisor") ||
 			gasLimit >= parentGasLimit + parentGasLimit / chainParams().u256Param("gasLimitBoundDivisor"))
-			BOOST_THROW_EXCEPTION(InvalidGasLimit() << errinfo_min((bigint)parentGasLimit - parentGasLimit / chainParams().u256Param("gasLimitBoundDivisor")) << errinfo_got((bigint)gasLimit) << errinfo_max((bigint)parentGasLimit + parentGasLimit / chainParams().u256Param("gasLimitBoundDivisor")));
+			BOOST_THROW_EXCEPTION(
+				InvalidGasLimit()
+				<< errinfo_min((bigint)((bigint)parentGasLimit - (bigint)(parentGasLimit / chainParams().u256Param("gasLimitBoundDivisor"))))
+				<< errinfo_got((bigint)gasLimit)
+				<< errinfo_max((bigint)((bigint)parentGasLimit + parentGasLimit / chainParams().u256Param("gasLimitBoundDivisor")))
+			);
 	}
 
 	// check it hashes according to proof of work or that it's the genesis block.

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -110,7 +110,11 @@ int main( int argc, char* argv[] )
 	try
 	{
 		framework::init(fake_init_func, argc, argv);
-#if BOOST_VERSION >= 105900
+#if BOOST_VERSION >= 106000
+			if (true)
+			{
+				test_case_counter filter;
+#elif BOOST_VERSION >= 105900
 		if(!runtime_config::test_to_run().empty())
 		{
 			test_case_counter filter;
@@ -126,10 +130,13 @@ int main( int argc, char* argv[] )
 
 		results_reporter::make_report();
 
+#if BOOST_VERSION >= 106000
+		return results_collector.results(framework::master_test_suite().p_id).result_code();
+#else
 		return runtime_config::no_result_code()
 					? boost::exit_success
 					: results_collector.results(framework::master_test_suite().p_id).result_code();
-
+#endif
 	}
 	catch (framework::nothing_to_test const&)
 	{


### PR DESCRIPTION
This PR fixes the libethereum build for the new boost 1.60 version.

@winsvega Please have a look at the tests fix. Understand that what you are doing [in boostTest](https://github.com/ethereum/libethereum/blob/develop/test/boostTest.cpp#L113) has to change. We can't be fixing it for each new boost release.

Please don't use internal boost functions.
