### PR TITLE
Fix sequence number bug.

### DIFF
--- a/libevmasm/ControlFlowGraph.cpp
+++ b/libevmasm/ControlFlowGraph.cpp
@@ -284,7 +284,7 @@ void ControlFlowGraph::gatherKnowledge()
 					unknownJumpEncountered = true;
 					for (auto const& it: m_blocks)
 						if (it.second.begin < it.second.end && m_items[it.second.begin].type() == Tag)
-							workQueue.push_back(WorkQueueItem{it.first, emptyState, set<BlockId>()});
+							workQueue.push_back(WorkQueueItem{it.first, emptyState->copy(), set<BlockId>()});
 				}
 			}
 			else

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -175,7 +175,7 @@ template <class _Mapping> void intersect(_Mapping& _this, _Mapping const& _other
 			it = _this.erase(it);
 }
 
-void KnownState::reduceToCommonKnowledge(KnownState const& _other)
+void KnownState::reduceToCommonKnowledge(KnownState const& _other, bool _combineSequenceNumbers)
 {
 	int stackDiff = m_stackHeight - _other.m_stackHeight;
 	for (auto it = m_stackElements.begin(); it != m_stackElements.end();)
@@ -213,9 +213,11 @@ void KnownState::reduceToCommonKnowledge(KnownState const& _other)
 
 	intersect(m_storageContent, _other.m_storageContent);
 	intersect(m_memoryContent, _other.m_memoryContent);
+	if (_combineSequenceNumbers)
+		m_sequenceNumber = max(m_sequenceNumber, _other.m_sequenceNumber);
 }
 
-bool KnownState::operator==(const KnownState& _other) const
+bool KnownState::operator==(KnownState const& _other) const
 {
 	if (m_storageContent != _other.m_storageContent || m_memoryContent != _other.m_memoryContent)
 		return false;

--- a/libevmasm/KnownState.h
+++ b/libevmasm/KnownState.h
@@ -100,13 +100,12 @@ public:
 	void reset() { resetStorage(); resetMemory(); resetStack(); }
 
 	unsigned sequenceNumber() const { return m_sequenceNumber; }
-	/// Manually increments the storage and memory sequence number.
-	void incrementSequenceNumber() { m_sequenceNumber += 2; }
 
 	/// Replaces the state by the intersection with _other, i.e. only equal knowledge is retained.
 	/// If the stack heighht is different, the smaller one is used and the stack is compared
 	/// relatively.
-	void reduceToCommonKnowledge(KnownState const& _other);
+	/// @param _combineSequenceNumbers if true, sets the sequence number to the maximum of both
+	void reduceToCommonKnowledge(KnownState const& _other, bool _combineSequenceNumbers);
 
 	/// @returns a shared pointer to a copy of this state.
 	std::shared_ptr<KnownState> copy() const { return std::make_shared<KnownState>(*this); }


### PR DESCRIPTION
This bug resulted in incorrect storage access in some situations.
The reason was that when intersecting states, the sequence numbers
were not handled and thus some operations with too low
sequence numbers were used during code generation.

DEPENDS:
{
"solidity":"fix_storage"
}

Fixes solidity#313
