### PR TITLE
Switch llvm::Argument processing to use iterators

### DIFF
--- a/evmjit/libevmjit/Arith256.cpp
+++ b/evmjit/libevmjit/Arith256.cpp
@@ -81,9 +81,10 @@ llvm::Function* generateLongMulFunc(char const* _funcName, llvm::IntegerType* _t
 	func->setDoesNotAccessMemory();
 	func->setDoesNotThrow();
 
-	auto x = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* x = &(*iter++);
 	x->setName("x");
-	auto y = x->getNextNode();
+	llvm::Argument* y = &(*iter);
 	y->setName("y");
 
 	auto entryBB = llvm::BasicBlock::Create(func->getContext(), "Entry", func);
@@ -198,10 +199,11 @@ llvm::Function* createUDivRemFunc(llvm::Type* _type, llvm::Module& _module, char
 	auto zero = llvm::ConstantInt::get(_type, 0);
 	auto one = llvm::ConstantInt::get(_type, 1);
 
-	auto x = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* x = &(*iter++);
 	x->setName("x");
-	auto yArg = x->getNextNode();
-	yArg->setName("y");
+	llvm::Argument* y = &(*iter);
+	y->setName("y");
 
 	auto entryBB = llvm::BasicBlock::Create(_module.getContext(), "Entry", func);
 	auto mainBB = llvm::BasicBlock::Create(_module.getContext(), "Main", func);
@@ -210,17 +212,17 @@ llvm::Function* createUDivRemFunc(llvm::Type* _type, llvm::Module& _module, char
 	auto returnBB = llvm::BasicBlock::Create(_module.getContext(), "Return", func);
 
 	auto builder = IRBuilder{entryBB};
-	auto yLEx = builder.CreateICmpULE(yArg, x);
+	auto yLEx = builder.CreateICmpULE(y, x);
 	auto r0 = x;
 	builder.CreateCondBr(yLEx, mainBB, returnBB);
 
 	builder.SetInsertPoint(mainBB);
 	auto ctlzIntr = llvm::Intrinsic::getDeclaration(&_module, llvm::Intrinsic::ctlz, _type);
 	// both y and r are non-zero
-	auto yLz = builder.CreateCall(ctlzIntr, {yArg, builder.getInt1(true)}, "y.lz");
+	auto yLz = builder.CreateCall(ctlzIntr, {y, builder.getInt1(true)}, "y.lz");
 	auto rLz = builder.CreateCall(ctlzIntr, {r0, builder.getInt1(true)}, "r.lz");
 	auto i0 = builder.CreateNUWSub(yLz, rLz, "i0");
-	auto y0 = builder.CreateShl(yArg, i0);
+	auto y0 = builder.CreateShl(y, i0);
 	builder.CreateBr(loopBB);
 
 	builder.SetInsertPoint(loopBB);
@@ -296,9 +298,10 @@ llvm::Function* Arith256::getUDiv256Func(llvm::Module& _module)
 	func->setDoesNotThrow();
 	func->setDoesNotAccessMemory();
 
-	auto x = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* x = &(*iter++);
 	x->setName("x");
-	auto y = x->getNextNode();
+	llvm::Argument* y = &(*iter);
 	y->setName("y");
 
 	auto bb = llvm::BasicBlock::Create(_module.getContext(), {}, func);
@@ -320,9 +323,10 @@ llvm::Function* createURemFunc(llvm::Type* _type, llvm::Module& _module, char co
 	func->setDoesNotThrow();
 	func->setDoesNotAccessMemory();
 
-	auto x = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* x = &(*iter++);
 	x->setName("x");
-	auto y = x->getNextNode();
+	llvm::Argument* y = &(*iter);
 	y->setName("y");
 
 	auto bb = llvm::BasicBlock::Create(_module.getContext(), {}, func);
@@ -364,9 +368,10 @@ llvm::Function* Arith256::getSDivRem256Func(llvm::Module& _module)
 	func->setDoesNotThrow();
 	func->setDoesNotAccessMemory();
 
-	auto x = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* x = &(*iter++);
 	x->setName("x");
-	auto y = x->getNextNode();
+	llvm::Argument* y = &(*iter);
 	y->setName("y");
 
 	auto bb = llvm::BasicBlock::Create(_module.getContext(), "", func);
@@ -410,9 +415,10 @@ llvm::Function* Arith256::getSDiv256Func(llvm::Module& _module)
 	func->setDoesNotThrow();
 	func->setDoesNotAccessMemory();
 
-	auto x = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* x = &(*iter++);
 	x->setName("x");
-	auto y = x->getNextNode();
+	llvm::Argument* y = &(*iter);
 	y->setName("y");
 
 	auto bb = llvm::BasicBlock::Create(_module.getContext(), {}, func);
@@ -436,9 +442,10 @@ llvm::Function* Arith256::getSRem256Func(llvm::Module& _module)
 	func->setDoesNotThrow();
 	func->setDoesNotAccessMemory();
 
-	auto x = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* x = &(*iter++);
 	x->setName("x");
-	auto y = x->getNextNode();
+	llvm::Argument* y = &(*iter);
 	y->setName("y");
 
 	auto bb = llvm::BasicBlock::Create(_module.getContext(), {}, func);
@@ -459,9 +466,10 @@ llvm::Function* Arith256::getExpFunc()
 		m_exp->setDoesNotThrow();
 		m_exp->setDoesNotAccessMemory();
 
-		auto base = &m_exp->getArgumentList().front();
+		auto iter = m_exp->arg_begin();
+		llvm::Argument* base = &(*iter++);
 		base->setName("base");
-		auto exponent = base->getNextNode();
+		llvm::Argument* exponent = &(*iter);
 		exponent->setName("exponent");
 
 		InsertPointGuard guard{m_builder};

--- a/evmjit/libevmjit/Array.cpp
+++ b/evmjit/libevmjit/Array.cpp
@@ -32,9 +32,10 @@ llvm::Function* Array::createArrayPushFunc()
 	func->setDoesNotThrow();
 	func->setDoesNotCapture(1);
 
-	auto arrayPtr = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* arrayPtr = &(*iter++);
 	arrayPtr->setName("arrayPtr");
-	auto value = arrayPtr->getNextNode();
+	llvm::Argument* value = &(*iter);
 	value->setName("value");
 
 	InsertPointGuard guard{m_builder};
@@ -82,11 +83,12 @@ llvm::Function* Array::createArraySetFunc()
 	func->setDoesNotThrow();
 	func->setDoesNotCapture(1);
 
-	auto arrayPtr = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* arrayPtr = &(*iter++);
 	arrayPtr->setName("arrayPtr");
-	auto index = arrayPtr->getNextNode();
+	llvm::Argument* index = &(*iter++);
 	index->setName("index");
-	auto value = index->getNextNode();
+	llvm::Argument* value = &(*iter);
 	value->setName("value");
 
 	InsertPointGuard guard{m_builder};
@@ -106,9 +108,10 @@ llvm::Function* Array::createArrayGetFunc()
 	func->setDoesNotThrow();
 	func->setDoesNotCapture(1);
 
-	auto arrayPtr = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* arrayPtr = &(*iter++);
 	arrayPtr->setName("arrayPtr");
-	auto index = arrayPtr->getNextNode();
+	llvm::Argument* index = &(*iter++);
 	index->setName("index");
 
 	InsertPointGuard guard{m_builder};
@@ -128,9 +131,10 @@ llvm::Function* Array::createGetPtrFunc()
 	func->setDoesNotThrow();
 	func->setDoesNotCapture(1);
 
-	auto arrayPtr = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* arrayPtr = &(*iter++);
 	arrayPtr->setName("arrayPtr");
-	auto index = arrayPtr->getNextNode();
+	llvm::Argument* index = &(*iter++);
 	index->setName("index");
 
 	InsertPointGuard guard{m_builder};
@@ -186,9 +190,10 @@ llvm::Function* Array::createExtendFunc()
 	func->setDoesNotThrow();
 	func->setDoesNotCapture(1);
 
-	auto arrayPtr = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* arrayPtr = &(*iter++);
 	arrayPtr->setName("arrayPtr");
-	auto newSize = arrayPtr->getNextNode();
+	llvm::Argument* newSize = &(*iter++);
 	newSize->setName("newSize");
 
 	InsertPointGuard guard{m_builder};

--- a/evmjit/libevmjit/BasicBlock.cpp
+++ b/evmjit/libevmjit/BasicBlock.cpp
@@ -165,17 +165,18 @@ llvm::Function* LocalStack::getStackPrepareFunc()
 	auto updateBB = llvm::BasicBlock::Create(func->getContext(), "Update", func);
 	auto outOfStackBB = llvm::BasicBlock::Create(func->getContext(), "OutOfStack", func);
 
-	auto base = &func->getArgumentList().front();
+	auto iter = func->arg_begin();
+	llvm::Argument* base = &(*iter++);
 	base->setName("base");
-	auto sizePtr = base->getNextNode();
+	llvm::Argument* sizePtr = &(*iter++);
 	sizePtr->setName("size.ptr");
-	auto min = sizePtr->getNextNode();
+	llvm::Argument* min = &(*iter++);
 	min->setName("min");
-	auto max = min->getNextNode();
+	llvm::Argument* max = &(*iter++);
 	max->setName("max");
-	auto diff = max->getNextNode();
+	llvm::Argument* diff = &(*iter++);
 	diff->setName("diff");
-	auto jmpBuf = diff->getNextNode();
+	llvm::Argument* jmpBuf = &(*iter);
 	jmpBuf->setName("jmpBuf");
 
 	InsertPointGuard guard{m_builder};

--- a/evmjit/libevmjit/Compiler.cpp
+++ b/evmjit/libevmjit/Compiler.cpp
@@ -109,12 +109,16 @@ void Compiler::resolveJumps()
 	// Iterate through all EVM instructions blocks (skip first one and last 4 - special blocks).
 	for (auto it = std::next(m_mainFunc->begin()), end = std::prev(m_mainFunc->end(), 4); it != end; ++it)
 	{
-		auto nextBlock = it->getNextNode(); // If the last code block, that will be "stop" block.
+		auto nextBlockIter = it;
+		++nextBlockIter; // If the last code block, that will be "stop" block.
+		auto currentBlockPtr = &(*it);
+		auto nextBlockPtr = &(*nextBlockIter);
+		
 		auto term = it->getTerminator();
 		llvm::BranchInst* jump = nullptr;
 
 		if (!term) // Block may have no terminator if the next instruction is a jump destination.
-			IRBuilder{it}.CreateBr(nextBlock);
+			IRBuilder{currentBlockPtr}.CreateBr(nextBlockPtr);
 		else if ((jump = llvm::dyn_cast<llvm::BranchInst>(term)) && jump->getSuccessor(0) == m_jumpTableBB)
 		{
 			auto destIdx = llvm::cast<llvm::ValueAsMetadata>(jump->getMetadata(c_destIdxLabel)->getOperand(0))->getValue();
@@ -125,10 +129,10 @@ void Compiler::resolveJumps()
 				jump->setSuccessor(0, bb);
 			}
 			else
-				jumpTableInput->addIncoming(destIdx, it); // Fill up PHI node
+				jumpTableInput->addIncoming(destIdx, currentBlockPtr); // Fill up PHI node
 
 			if (jump->isConditional())
-				jump->setSuccessor(1, nextBlock); // Set next block for conditional jumps
+				jump->setSuccessor(1, &(*nextBlockIter)); // Set next block for conditional jumps
 		}
 	}
 

--- a/evmjit/libevmjit/Ext.cpp
+++ b/evmjit/libevmjit/Ext.cpp
@@ -63,8 +63,9 @@ llvm::Value* Ext::getArgAlloca()
 	{
 		InsertPointGuard g{m_builder};
 		auto allocaIt = getMainFunction()->front().begin();
+		auto allocaPtr = &(*allocaIt);
 		std::advance(allocaIt, m_argCounter); // Skip already created allocas
-		m_builder.SetInsertPoint(allocaIt);
+		m_builder.SetInsertPoint(allocaPtr);
 		a = m_builder.CreateAlloca(Type::Word, nullptr, {"a.", std::to_string(m_argCounter)});
 	}
 	++m_argCounter;

--- a/evmjit/libevmjit/GasMeter.cpp
+++ b/evmjit/libevmjit/GasMeter.cpp
@@ -164,11 +164,12 @@ GasMeter::GasMeter(IRBuilder& _builder, RuntimeManager& _runtimeManager) :
 	auto updateBB = llvm::BasicBlock::Create(_builder.getContext(), "Update", m_gasCheckFunc);
 	auto outOfGasBB = llvm::BasicBlock::Create(_builder.getContext(), "OutOfGas", m_gasCheckFunc);
 
-	auto gasPtr = &m_gasCheckFunc->getArgumentList().front();
+	auto iter = m_gasCheckFunc->arg_begin();
+	llvm::Argument* gasPtr = &(*iter++);
 	gasPtr->setName("gasPtr");
-	auto cost = gasPtr->getNextNode();
+	llvm::Argument* cost = &(*iter++);
 	cost->setName("cost");
-	auto jmpBuf = cost->getNextNode();
+	llvm::Argument* jmpBuf = &(*iter);
 	jmpBuf->setName("jmpBuf");
 
 	InsertPointGuard guard(m_builder);

--- a/evmjit/libevmjit/Memory.cpp
+++ b/evmjit/libevmjit/Memory.cpp
@@ -31,15 +31,16 @@ llvm::Function* Memory::getRequireFunc()
 		func = llvm::Function::Create(llvm::FunctionType::get(Type::Void, argTypes, false), llvm::Function::PrivateLinkage, "mem.require", getModule());
 		func->setDoesNotThrow();
 
-		auto mem = &func->getArgumentList().front();
+		auto iter = func->arg_begin();
+		llvm::Argument* mem = &(*iter++);
 		mem->setName("mem");
-		auto blkOffset = mem->getNextNode();
+		llvm::Argument* blkOffset = &(*iter++);
 		blkOffset->setName("blkOffset");
-		auto blkSize = blkOffset->getNextNode();
+		llvm::Argument* blkSize = &(*iter++);
 		blkSize->setName("blkSize");
-		auto jmpBuf = blkSize->getNextNode();
+		llvm::Argument* jmpBuf = &(*iter++);
 		jmpBuf->setName("jmpBuf");
-		auto gas = jmpBuf->getNextNode();
+		llvm::Argument* gas = &(*iter);
 		gas->setName("gas");
 
 		auto preBB = llvm::BasicBlock::Create(func->getContext(), "Pre", func);
@@ -105,14 +106,16 @@ llvm::Function* Memory::createFunc(bool _isStore, llvm::Type* _valueType)
 	InsertPointGuard guard(m_builder); // Restores insert point at function exit
 
 	m_builder.SetInsertPoint(llvm::BasicBlock::Create(func->getContext(), {}, func));
-	auto mem = &func->getArgumentList().front();
+	
+	auto iter = func->arg_begin();
+	llvm::Argument* mem = &(*iter++);
 	mem->setName("mem");
-	auto index = mem->getNextNode();
+	llvm::Argument* index = &(*iter++);
 	index->setName("index");
 
 	if (_isStore)
 	{
-		auto valueArg = index->getNextNode();
+		llvm::Argument* valueArg = &(*iter);
 		valueArg->setName("value");
 		auto value = isWord ? Endianness::toBE(m_builder, valueArg) : valueArg;
 		auto memPtr = m_memory.getPtr(mem, m_builder.CreateTrunc(index, Type::Size));

--- a/evmjit/libevmjit/Optimizer.cpp
+++ b/evmjit/libevmjit/Optimizer.cpp
@@ -57,7 +57,8 @@ bool LongJmpEliminationPass::runOnFunction(llvm::Function& _func)
 		{
 			auto longjmp = term->getPrevNode();
 			assert(llvm::isa<llvm::CallInst>(longjmp));
-			retPhi->addIncoming(abortCode, bbIt);
+			auto bbPtr = &(*bbIt);
+			retPhi->addIncoming(abortCode, bbPtr);
 			llvm::ReplaceInstWithInst(term, llvm::BranchInst::Create(&exitBB));
 			longjmp->eraseFromParent();
 			modified = true;


### PR DESCRIPTION
Work-in-progress on switching processing of llvm::Argument elements (mainly from llvm::Function) to use iterators, rather than getNextNode(), to address build breaks against LLVM HEAD (work towards 3.9).

These changes should work with older LLVM versions too (such as 3.7.1, the current stable version).

Seeking to resolve https://github.com/ethereum/webthree-umbrella/issues/136

Still needs finishing up and review and squashing.
