### PR TITLE
Move OverlayDB.cpp/.h from libdevcrypto to libdevcore.

### DIFF
--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -26,7 +26,7 @@
 #include <libdevcore/Common.h>
 #include <libdevcore/RLP.h>
 #include <libdevcore/TrieDB.h>
-#include <libdevcrypto/OverlayDB.h>
+#include <libdevcore/OverlayDB.h>
 #include <libethcore/Exceptions.h>
 #include <libethcore/BlockHeader.h>
 #include <libethcore/ChainOperationParams.h>

--- a/libethereum/CachedAddressState.cpp
+++ b/libethereum/CachedAddressState.cpp
@@ -22,7 +22,7 @@
 #include "CachedAddressState.h"
 #include <libdevcore/TrieDB.h>
 #include <libdevcrypto/Common.h>
-#include <libdevcrypto/OverlayDB.h>
+#include <libdevcore/OverlayDB.h>
 #include "Account.h"
 #include "State.h"
 using namespace std;

--- a/libethereum/EthereumHost.h
+++ b/libethereum/EthereumHost.h
@@ -33,7 +33,7 @@
 #include <libdevcore/Worker.h>
 #include <libethcore/Common.h>
 #include <libp2p/Common.h>
-#include <libdevcrypto/OverlayDB.h>
+#include <libdevcore/OverlayDB.h>
 #include "CommonNet.h"
 #include "EthereumPeer.h"
 

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -26,7 +26,7 @@
 #include <libdevcore/Common.h>
 #include <libdevcore/RLP.h>
 #include <libdevcore/TrieDB.h>
-#include <libdevcrypto/OverlayDB.h>
+#include <libdevcore/OverlayDB.h>
 #include <libethcore/Exceptions.h>
 #include <libethcore/BlockHeader.h>
 #include <libethereum/GenericMiner.h>


### PR DESCRIPTION
This PR is part of ethereum/webthree-umbrella#146.

DEPENDS:
{
  "libweb3core": "develop"
}
