### PR TITLE
Removed unused private member variable, which was used in PV60.

### DIFF
--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -136,7 +136,6 @@ private:
 	Handler<> m_bqRoomAvailable;				///< Triggered once block queue has space for more blocks
 	mutable RecursiveMutex x_sync;
 	SyncState m_state = SyncState::NotSynced;	///< Current sync state
-	unsigned m_estimatedHashes = 0;				///< Number of estimated hashes for the last peer over PV60. Used for status reporting only.
 	h256Hash m_knownNewHashes; 					///< New hashes we know about use for logging only
 	unsigned m_startingBlock = 0;      	    	///< Last block number for the start of sync
 	unsigned m_highestBlock = 0;       	     	///< Highest block number seen


### PR DESCRIPTION
This was causing a build warning on OS X.
