### PR TITLE
Fix OS X build break versus LLVM HEAD

### DIFF
--- a/evmjit/libevmjit/Optimizer.cpp
+++ b/evmjit/libevmjit/Optimizer.cpp
@@ -39,7 +39,8 @@ char LongJmpEliminationPass::ID = 0;
 
 bool LongJmpEliminationPass::runOnFunction(llvm::Function& _func)
 {
-	if (&_func != _func.getParent()->begin())
+	auto iter = _func.getParent()->begin();
+	if (&_func != &(*iter))
 		return false;
 
 	auto& mainFunc = _func;


### PR DESCRIPTION
This looks like it has been caused by cleanup of iterator semantics in LLVM, which exposed an implicit conversation which isn't allowed anymore.
