### PR TITLE
OS X - Correct default path to LLVM HEAD install's cmake files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (EVMJIT)
 		if (DEFINED MSVC)
 			set(LLVM_DIR "${ETH_CMAKE_DIR}/extdep/install/windows/x64/share/llvm/cmake")
 		elseif (DEFINED APPLE)
-			set(LLVM_DIR "/usr/local/opt/llvm/share/llvm/cmake")
+			set(LLVM_DIR "/usr/local/opt/llvm/lib/cmake/llvm")
 		endif()
 	endif()
 


### PR DESCRIPTION
This path changed at some point in the past month or two.
In the absence of this path being correct, cmake invocations have to have this path explicitly passed (and in fact our instructions do, which I never knew the reason for).    So we shouldn't need that.    The default here should just be correct :-)
