### PR TITLE
Fix for warning in ChainParams which was introducing a warning for openSUSE builds

### DIFF
--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -37,7 +37,7 @@ class SealEngineFace;
 struct ChainParams: public ChainOperationParams
 {
 	ChainParams();
-	ChainParams(ChainParams const& _org) = default;
+	ChainParams(ChainParams const& /*_org*/) = default;
 	ChainParams(std::string const& _s, h256 const& _stateRoot = h256());
 	ChainParams(bytes const& _genesisRLP, AccountMap const& _state) { populateFromGenesis(_genesisRLP, _state); }
 	ChainParams(std::string const& _json, bytes const& _genesisRLP, AccountMap const& _state): ChainParams(_json) { populateFromGenesis(_genesisRLP, _state); }


### PR DESCRIPTION
Fix for warning in ChainParams which was introducing a warning for openSUSE builds
For some reason warnings-as-errors are enabled on the platform, so this was showing as a build error.
Thanks to @daschmidty for reporting this issue.
Fixes https://github.com/ethereum/webthree-umbrella/issues/302
