### PR TITLE
Fixed DAG chunking

### DIFF
--- a/libethash-cl/ethash_cl_miner_kernel.cl
+++ b/libethash-cl/ethash_cl_miner_kernel.cl
@@ -554,7 +554,7 @@ __kernel void ethash_search(
 
 	if (as_ulong(as_uchar8(hash.ulongs[0]).s76543210) < target)
 	{
-		uint slot = min(MAX_OUTPUTS, atomic_inc(&g_output[0]) + 1);
+		uint slot = min(convert_uint(MAX_OUTPUTS), convert_uint(atomic_inc(&g_output[0]) + 1));
 		g_output[slot] = gid;
 	}
 }


### PR DESCRIPTION
Fixed support of chunking the DAG on GPUs unable to allocate a continuous block of memory large enough for the entire DAG.

The problem was in the offsets calculated in the CL kernel.
Also removed DAG duplication on chunked buffer mapping.
