### PR TITLE
Sync stability fixes

### DIFF
--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -425,7 +425,7 @@ void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP
 	if (itemCount == 0)
 	{
 		clog(NetAllDetail) << "Peer does not have the blocks requested";
-		return;
+		_peer->addRating(-1);
 	}
 	for (unsigned i = 0; i < itemCount; i++)
 	{
@@ -527,6 +527,11 @@ void BlockChainSync::onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP 
 	{
 		clog(NetAllDetail) << "Ignored blocks while waiting";
 		return;
+	}
+	if (itemCount == 0)
+	{
+		clog(NetAllDetail) << "Peer does not have the blocks requested";
+		_peer->addRating(-1);
 	}
 	for (unsigned i = 0; i < itemCount; i++)
 	{

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -422,6 +422,11 @@ void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP
 		clog(NetAllDetail) << "Ignored blocks while waiting";
 		return;
 	}
+	if (itemCount == 0)
+	{
+		clog(NetAllDetail) << "Peer does not have the blocks requested";
+		return;
+	}
 	for (unsigned i = 0; i < itemCount; i++)
 	{
 		BlockHeader info(_r[i].data(), HeaderData);
@@ -512,7 +517,7 @@ void BlockChainSync::onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP 
 	RecursiveGuard l(x_sync);
 	DEV_INVARIANT_CHECK;
 	size_t itemCount = _r.itemCount();
-	clog(NetMessageSummary) << "BlocksBodies (" << dec << itemCount << "entries)" << (itemCount ? "" : ": NoMoreHeaders");
+	clog(NetMessageSummary) << "BlocksBodies (" << dec << itemCount << "entries)" << (itemCount ? "" : ": NoMoreBodies");
 	clearPeerDownload(_peer);
 	if (m_state != SyncState::Blocks && m_state != SyncState::NewBlocks && m_state != SyncState::Waiting) {
 		clog(NetMessageSummary) << "Ignoring unexpected blocks";

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -112,16 +112,9 @@ template<typename T> void removeAllStartingWith(std::map<unsigned, std::vector<T
 		return;
 	}
 	--lower;
-	if (lower->first <= _number && (lower->first + lower->second.size()) > _number) {
+	if (lower->first <= _number && (lower->first + lower->second.size()) > _number)
 		lower->second.erase(lower->second.begin() + (_number - lower->first), lower->second.end());
-		++lower;
-		_container.erase(lower, _container.end());
-	}
-	else
-	{
-		++lower;
-		_container.erase(lower, _container.end());
-	}
+	_container.erase(++lower, _container.end());
 }
 
 template<typename T> void mergeInto(std::map<unsigned, std::vector<T>>& _container, unsigned _number, T&& _data)
@@ -304,7 +297,7 @@ void BlockChainSync::requestBlocks(std::shared_ptr<EthereumPeer> _peer)
 			if (!m_headers.empty())
 				start = std::min(start, m_headers.begin()->first - 1);
 			m_lastImportedBlock = start;
-            m_lastImportedBlockHash = host().chain().numberHash(start);
+			m_lastImportedBlockHash = host().chain().numberHash(start);
 
 			if (start <= 1)
 				m_haveCommonHeader = true; //reached genesis
@@ -494,7 +487,7 @@ void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP
 			}
 
 			mergeInto(m_headers, blockNumber, std::move(hdr));
-			if (headerId.transactionsRoot == EmptyTrie && headerId.uncles ==  EmptyListSHA3)
+			if (headerId.transactionsRoot == EmptyTrie && headerId.uncles == EmptyListSHA3)
 			{
 				//empty body, just mark as downloaded
 				RLPStream r(2);

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -148,6 +148,7 @@ private:
 	std::unordered_map<HeaderId, unsigned, HeaderIdHash> m_headerIdToNumber;
 	bool m_haveCommonHeader = false;			///< True if common block for our and remote chain has been found
 	unsigned m_lastImportedBlock = 0; 			///< Last imported block number
+	h256 m_lastImportedBlockHash; 			///< Last imported block hash
 	u256 m_syncingTotalDifficulty;				///< Highest peer difficulty
 
 private:


### PR DESCRIPTION
Continuation of https://github.com/ethereum/libethereum/pull/202
- Fixed assertion failure on mismatched block
- Better fork recovery

Ideas for future work:
- Detect and disable peers which are on forked beyond repair (> 1000 blocks)
