### PR TITLE
remove libjsengine

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,10 +16,6 @@ add_subdirectory(libevm)
 add_subdirectory(libnatspec)
 add_subdirectory(external-dependencies)
 
-if (JSCONSOLE)
-	add_subdirectory(libjsengine)
-endif()
-
 set(SRC_LIST ${SRC_LIST} ${SRC})
 
 set(EXECUTABLE testeth)


### PR DESCRIPTION
DEPENDS:
{
"webthree":"removelibjsconsole",
"webthree-helpers":"removejsconsole"
}
connects to https://github.com/ethereum/webthree-umbrella/issues/264
