### PR TITLE
Moved LLVM-specific CMake content from the top-level CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,19 +22,7 @@ include(EthOptions)
 configure_project(CPUID CURL VMTRACE ROCKSDB OLYMPIC PARANOID TESTS ETHASHCL EVMJIT FATDB)
 
 if (EVMJIT)
-	if (NOT DEFINED LLVM_DIR)
-		if (DEFINED MSVC)
-			set(LLVM_DIR "${ETH_CMAKE_DIR}/extdep/install/windows/x64/share/llvm/cmake")
-		elseif (DEFINED APPLE)
-			set(LLVM_DIR "/usr/local/opt/llvm37/lib/llvm-3.7/share/llvm/cmake")
-		endif()
-	endif()
-
 	add_subdirectory(evmjit)
-	if (DEFINED MSVC)
-		set(EVMJIT_DLLS_LOCAL $<TARGET_FILE:evmjit>)
-		set(EVMJIT_DLLS optimized ${EVMJIT_DLLS_LOCAL} debug ${EVMJIT_DLLS_LOCAL} PARENT_SCOPE)
-	endif()
 endif()
 
 # core libraries

--- a/evmjit/CMakeLists.txt
+++ b/evmjit/CMakeLists.txt
@@ -20,6 +20,12 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT SANITIZE)
 endif()
 
 # LLVM
+if (DEFINED MSVC)
+	set(LLVM_DIR "${ETH_CMAKE_DIR}/extdep/install/windows/x64/share/llvm/cmake")
+elseif (DEFINED APPLE)
+	set(LLVM_DIR "/usr/local/opt/llvm37/lib/llvm-3.7/share/llvm/cmake")
+endif()
+
 find_package(LLVM REQUIRED CONFIG)
 if (${LLVM_VERSION} VERSION_LESS 3.7)
 	message(FATAL_ERROR "Incompatible LLVM version ${LLVM_VERSION}")
@@ -29,3 +35,8 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 llvm_map_components_to_libnames(LLVM_LIBS core support mcjit x86asmparser x86codegen ipo)
 
 add_subdirectory(libevmjit)
+
+if (DEFINED MSVC)
+	set(EVMJIT_DLLS_LOCAL $<TARGET_FILE:evmjit>)
+	set(EVMJIT_DLLS optimized ${EVMJIT_DLLS_LOCAL} debug ${EVMJIT_DLLS_LOCAL} PARENT_SCOPE)
+endif()


### PR DESCRIPTION
Moved LLVM-specific CMake content from the top-level CMakeLists.txt file for libethereum down into the CMake file for the evmjit module.

Also changed the setting of LLVM_DIR on OS X and Windows from only happening if already undefined to being an unconditional override of any existing settings.    We always want to use the CMake files in those locations and providing the ability for an end-user to override that is a malfeature.   This change is to address a specific break which I am seeing on my MacBook right now, where LLVM_DIR was not undefined.   It was incorrectly defined, and that broke the build.    That won't be possible anymore.     It looks like it was being set to LLVM_DIR-NOT-FOUND by some other element within the CMake process, and that was breaking things here.
