### PR TITLE
Added ifdefs around pre-processor symbols in the template for ConfigInfo.h.in

### DIFF
--- a/ConfigInfo.h.in
+++ b/ConfigInfo.h.in
@@ -1,4 +1,9 @@
 #pragma once
 
+#ifndef ETH_FATDB
 #define ETH_FATDB @ETH_FATDB@
+#endif
+
+#ifndef ETH_EVMJIT
 #define ETH_EVMJIT @ETH_EVMJIT@
+#endif


### PR DESCRIPTION
I will commit this change as soon as Jenkins shows green, because it will then mean that the following PRs to eliminate this file can be treated atomically.
