### PR TITLE
Please don't ask me why. This partly reverts c1d0429ce604.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ configure_project(CPUID CURL VMTRACE ROCKSDB OLYMPIC PARANOID TESTS ETHASHCL EVM
 
 if (EVMJIT)
 	add_subdirectory(evmjit)
+	if (DEFINED MSVC)
+		set(EVMJIT_DLLS_LOCAL $<TARGET_FILE:evmjit>)
+		set(EVMJIT_DLLS optimized ${EVMJIT_DLLS_LOCAL} debug ${EVMJIT_DLLS_LOCAL} PARENT_SCOPE)
+	endif()
+
 endif()
 
 # core libraries

--- a/evmjit/CMakeLists.txt
+++ b/evmjit/CMakeLists.txt
@@ -35,8 +35,3 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 llvm_map_components_to_libnames(LLVM_LIBS core support mcjit x86asmparser x86codegen ipo)
 
 add_subdirectory(libevmjit)
-
-if (DEFINED MSVC)
-	set(EVMJIT_DLLS_LOCAL $<TARGET_FILE:evmjit>)
-	set(EVMJIT_DLLS optimized ${EVMJIT_DLLS_LOCAL} debug ${EVMJIT_DLLS_LOCAL} PARENT_SCOPE)
-endif()


### PR DESCRIPTION
This at least changes the values of the `EVMJIT_DLLS` variables in some contexts (verified by using cmake's `message').
