### PR TITLE
Remove stray obsoleted configinfo.h generation template input file.

### DIFF
--- a/ConfigInfo.h.in
+++ b/ConfigInfo.h.in
@@ -1,9 +1,0 @@
-#pragma once
-
-#ifndef ETH_FATDB
-#define ETH_FATDB @ETH_FATDB@
-#endif
-
-#ifndef ETH_EVMJIT
-#define ETH_EVMJIT @ETH_EVMJIT@
-#endif


### PR DESCRIPTION
We don't actually need the ConfigInfo.h file anymore.    The changes to add these two defines to the compiler command-line were already committed.    The changes to remove the CMake generation step were already committed.

But this input file for that old process was accidentally left behind and just needs deleting.
