### PR TITLE
Upstreamed versions of my BuildInfo.h path edits from the cpp-ethereum repo merger branch

### DIFF
--- a/ethkey/main.cpp
+++ b/ethkey/main.cpp
@@ -27,7 +27,11 @@
 #include <libdevcore/FileSystem.h>
 #include <libdevcore/Log.h>
 #include <libethcore/KeyManager.h>
+#if ETH_AFTER_REPOSITORY_MERGE
+#include "cpp-ethereum/BuildInfo.h"
+#else
 #include "ethereum/BuildInfo.h"
+#endif // ETH_AFTER_REPOSITORY_MERGE
 #include "KeyAux.h"
 using namespace std;
 using namespace dev;

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -52,7 +52,11 @@
 #include <jsonrpccpp/client/connectors/httpclient.h>
 #endif // ETH_JSONRPC
 
+#if ETH_AFTER_REPOSITORY_MERGE
+#include "cpp-ethereum/BuildInfo.h"
+#else
 #include "ethereum/BuildInfo.h"
+#endif // ETH_AFTER_REPOSITORY_MERGE
 
 #if ETH_JSONRPC
 #include "PhoneHome.h"


### PR DESCRIPTION
They are inside pre-processor conditionals, which will be used to bridge the migration gap, and then removed when we are on the other side.
This pattern lets us share identical code between the two directory structures.
