### PR TITLE
fix #515: error: ignoring attributes on template argument 'cl_int {aka int}' 

### DIFF
--- a/libethash-cl/cl.hpp
+++ b/libethash-cl/cl.hpp
@@ -22,7 +22,8 @@
  ******************************************************************************/
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+ 
 /*! \file
  *
  *   \brief C++ bindings for OpenCL 1.0 (rev 48) and OpenCL 1.1 (rev 33)    


### PR DESCRIPTION
On Arch with gcc 6.1 compilation of ethereum fails do to:

```
/webthree-umbrella/libethereum/libethash-cl/cl.hpp:2423:28: error: ignoring attributes on template argument 'cl_int {aka int}' [-Werror=ignored-attributes]
         VECTOR_CLASS<cl_int>* binaryStatus = NULL,
```

https://github.com/ethereum/webthree-umbrella/issues/515

It can be fixed by adding new pragam to cl.hpp

```
#pragma GCC diagnostic ignored "-Wignored-attributes"
```
