### PR TITLE
ignored-attributes pragma nested in __GNUC__ >= 6 condition

### DIFF
--- a/libethash-cl/cl.hpp
+++ b/libethash-cl/cl.hpp
@@ -22,7 +22,8 @@
  ******************************************************************************/
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+ 
 /*! \file
  *
  *   \brief C++ bindings for OpenCL 1.0 (rev 48) and OpenCL 1.1 (rev 33)    

--- a/libethash-cl/cl.hpp
+++ b/libethash-cl/cl.hpp
@@ -22,7 +22,10 @@
  ******************************************************************************/
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#pragma GCC diagnostic ignored "-Wignored-attributes"
+
+#if __GNUC__ >= 6
+    #pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
  
 /*! \file
  *


### PR DESCRIPTION
The pragma `#pragma GCC diagnostic ignored "-Wignored-attributes"`
was made conditional to  `__GNUC__ >= 6` as suggested by @5chdn
in the https://github.com/ethereum/libethereum/pull/255#issuecomment-219642537
