### PR TITLE
Update version number to 1.2.7.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(ethereum VERSION "1.2.6")
+project(ethereum VERSION "1.2.7")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Changes since 1.2.6:
- Password locking/unlocking fix
- Reject blocks above max block gas
- Support for FreeBSD builds
- Some tweaks in the usage of EVMJIT
