### PR TITLE
Fix the "mining doesn't return shares".

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -521,9 +521,11 @@ private:
 				f.onSolutionFound([&](EthashProofOfWork::Solution sol)
 				{
 					solution = sol;
-					return completed = true;
+					completed = true;
+					return true;
 				});
-				while(true)
+				
+				while (!completed)
 				{
 					auto mp = f.miningProgress();
 					f.resetMiningProgress();


### PR DESCRIPTION
This fix doesn't just revert to the previous code, which was causing warnings on FreeBSD.    Instead, it removes the unused 'i' variable, as Enrique's changes did, and also clarifies the semantics for 'completed'.
