### PR TITLE
Updated version to 1.2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(ethereum VERSION "1.2.7")
+project(ethereum VERSION "1.2.8")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Changes since 1.2.7:
- Update tests to 64bit block gas limit
- Updated EVMJIT sub-module, to remove accidental use of CMake 3.1 feature.   Back to CMake 3.0+ as min version.
- Fix "mining doesn't return shares" issue introduced as knock-on bug in 1.2.6
