### PR TITLE
Added warning suppression using pragmas for Debian

### DIFF
--- a/libethash/internal.c
+++ b/libethash/internal.c
@@ -238,6 +238,12 @@ static bool ethash_hash(
 
 	}
 
+// Workaround for incorrect warning in earlier GCC versions, which manifests on Debian 8 (Jesse)
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif // define (__GNUC__)
+
 	// compress mix
 	for (uint32_t w = 0; w != MIX_WORDS; w += 4) {
 		uint32_t reduction = mix->words[w + 0];
@@ -246,6 +252,10 @@ static bool ethash_hash(
 		reduction = reduction * FNV_PRIME ^ mix->words[w + 3];
 		mix->words[w / 4] = reduction;
 	}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif // define (__GNUC__)
 
 	fix_endian_arr32(mix->words, MIX_WORDS / 4);
 	memcpy(&ret->mix_hash, mix->bytes, 32);


### PR DESCRIPTION
It looks like older versions of GCC have slightly unreliable logic for array out-of-bounds detection.
Code in ethash which uses unions and arrays is firing a warning in both Debian Jesse (8.5) and in the ARM Linux cross-builds.
Debian Jesse uses GCC 4.9.2.   The cross-builds are using GCC 4.8.4.
Other distros are using GCC 5.x or even GCC 6.x (Arch).
