### PR TITLE
Updated version to 1.2.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(ethereum VERSION "1.2.8")
+project(ethereum VERSION "1.2.9")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Changes since 1.2.8:
- Added localized warning-suppressions to work around GCC bug which causing build errors in Debian Jesse.
