### PR TITLE
Switching some exception classes to use boost versions to resolve ARM Linux build breaks.

### DIFF
--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -27,7 +27,7 @@
 using namespace dev;
 using namespace dev::eth;
 
-namespace
+namespace // anonymous
 {
 
 static unsigned const c_depthLimit = 1024;
@@ -59,7 +59,7 @@ void goOnOffloadedStack(Executive& _e, OnOpFunc const& _onOp)
 
 	// Create new thread with big stack and join immediately.
 	// TODO: It is possible to switch the implementation to Boost.Context or similar when the API is stable.
-	std::exception_ptr exception;
+	boost::exception_ptr exception;
 	boost::thread{attrs, [&]{
 		try
 		{
@@ -67,11 +67,11 @@ void goOnOffloadedStack(Executive& _e, OnOpFunc const& _onOp)
 		}
 		catch (...)
 		{
-			exception = std::current_exception(); // Catch all exceptions to be rethrown in parent thread.
+			exception = boost::current_exception(); // Catch all exceptions to be rethrown in parent thread.
 		}
 	}}.join();
 	if (exception)
-		std::rethrow_exception(exception);
+		boost::rethrow_exception(exception);
 }
 
 void go(unsigned _depth, Executive& _e, OnOpFunc const& _onOp)
@@ -89,7 +89,9 @@ void go(unsigned _depth, Executive& _e, OnOpFunc const& _onOp)
 	else
 		_e.go(_onOp);
 }
-}
+
+} // anonymous namespace
+
 
 bool ExtVM::call(CallParameters& _p)
 {


### PR DESCRIPTION
CC @anthony-cros.

The classes in question are **exception_ptr**, **current_exception** and **rethrow_exception**, all of which are ONLY used in a single function within ExtVM.cpp.   Using the boost versions, rather than the std versions, allows us to work around a long-standing GLIBC issue where these classes are unavailable for architectures with incomplete atomic int support.

"std::exception_ptr is missing on architectures with incomplete atomic int support"
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58938

"std::exception_ptr not available for old x86 arch"
http://trac.wxwidgets.org/ticket/16634

"NDK: unable to use std::exception_ptr with GCC 4.8 on armeabi, GNU STL"
https://code.google.com/p/android/issues/detail?id=62648
