### PR TITLE
Fix libethereum build

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -78,7 +78,6 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 		r["stack"] = stack;
 	}
 
-	bool returned = false;
 	bool newContext = false;
 	Instruction lastInst = Instruction::STOP;
 
@@ -91,8 +90,6 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 	}
 	else if (m_lastInst.size() == ext.depth + 2)
 	{
-		// returned from old context
-		returned = true;
 		m_lastInst.pop_back();
 		lastInst = m_lastInst.back();
 	}


### PR DESCRIPTION
Fixes the "set but not used" variable build error for libethereum.

```
/home/lefteris/ew/libethereum/libethereum/Executive.cpp: In member function ‘void dev::eth::StandardTrace::operator()(uint64_t, uint64_t, dev::eth::Instruction, dev::bigint, dev::bigint, dev::bigint, dev::eth::VM*, const dev::eth::ExtVMFace*)’:
/home/lefteris/ew/libethereum/libethereum/Executive.cpp:81:7: error: variable ‘returned’ set but not used [-Werror=unused-but-set-variable]
  bool returned = false;
       ^~~~~~~~
cc1plus: all warnings being treated as errors
```
