### PR TITLE
Sleep if block is sealed but not yet ready for import.

### DIFF
--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -270,7 +270,7 @@ protected:
 	/// Magically called when m_tq needs syncing. Be nice and don't block.
 	void onTransactionQueueReady() { m_syncTransactionQueue = true; m_signalled.notify_all(); }
 
-	/// Magically called when m_tq needs syncing. Be nice and don't block.
+	/// Magically called when m_bq needs syncing. Be nice and don't block.
 	void onBlockQueueReady() { m_syncBlockQueue = true; m_signalled.notify_all(); }
 
 	/// Called when the post state has changed (i.e. when more transactions are in it or we're sealing on a new block).


### PR DESCRIPTION
This hopefully fixes the dreaded "invalid operation on sealed block" error. We occasionally still get mining timeouts from solidity tests, but they at least do not void the whole chain.
