### PR TITLE
Environment variable support in ethminer

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -91,6 +91,12 @@ inline std::string credits()
 	return out.str();
 }
 
+std::string getEnvVar(std::string const& key)
+{
+    char const* val = getenv(key.c_str());
+    return val == NULL ? std::string() : std::string(val);
+}
+
 class BadArgument: public Exception {};
 struct MiningChannel: public LogChannel
 {
@@ -116,6 +122,18 @@ public:
 		Ethash::init();
 		NoProof::init();
 		BasicAuthority::init();
+	}
+
+	void doEnv()
+	{
+		string minertype = getEnvVar("ETHTYPE");
+		if (!minertype.empty())
+			if (minertype == "opencl")
+				m_minerType = "opencl";
+
+		string minerurl = getEnvVar("ETHURL");
+		if (!minerurl.empty())
+			m_farmURL = minerurl;
 	}
 
 	bool interpretOption(int& i, int argc, char** argv)

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -70,6 +70,7 @@ int main(int argc, char** argv)
 {
 	MinerCLI m(MinerCLI::OperationMode::Farm);
 
+	m.doEnv();
 	for (int i = 1; i < argc; ++i)
 	{
 		string arg = argv[i];


### PR DESCRIPTION
Initial support of environment variables in ethminer.
For the start, you can specify URL and type of mining
via environment variables.
