### PR TITLE
Enable OpenCL mining on Mesa Free Drivers

### DIFF
--- a/libethash-cl/ethash_cl_miner_kernel.cl
+++ b/libethash-cl/ethash_cl_miner_kernel.cl
@@ -4,6 +4,8 @@
 // Bandwidth: 124533 MB/s
 // search kernel should fit in <= 84 VGPRS (3 wavefronts)
 
+#pragma OPENCL EXTENSION cl_clang_storage_class_specifiers : enable
+
 #define THREADS_PER_HASH (128 / 16)
 #define HASHES_PER_LOOP (GROUP_SIZE / THREADS_PER_HASH)
 


### PR DESCRIPTION
Mesa's OpenCL implementation, Clover, currently supports only OpenCL 1.1, and requires explicit enabling of an extension in order to support `static` storage class specifier. The extension is a `#pragma` directive, and therefore should not affect other OpenCL implementations.
