### PR TITLE
consolidate exception throws

### DIFF
--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -67,7 +67,11 @@ private:
 	void makeJumpDestTable(ExtVMFace& _ext);
 	uint64_t verifyJumpDest(u256 const& _dest);
 	void copyDataToMemory(bytesConstRef _data, u256*& m_SP);
-	void throwVMStackException(unsigned _size, unsigned _n, unsigned _d);
+	uint64_t memNeed(u256 _offset, u256 _size);
+	void throwOutOfGas();
+	void throwBadInstruction();
+	void throwBadJumpDestination();
+	void throwBadStack(unsigned _size, unsigned _n, unsigned _d);
 	void reportStackUse();
 
 	std::unordered_set<uint64_t> m_jumpDests;
@@ -113,9 +117,16 @@ private:
 	void caseCreate();
 	bool caseCallSetup(CallParameters*);
 	void caseCall();
-};
 
-void throwVMException(VMException);
+	template<class T> uint64_t toUint64(T v)
+	{
+		// check for overflow
+		if (v > 0x7FFFFFFFFFFFFFFF)
+			throwOutOfGas();
+		uint64_t w = uint64_t(v);
+		return w;
+	}
+	};
 
 }
 }

--- a/libevm/VMNoInline.cpp
+++ b/libevm/VMNoInline.cpp
@@ -28,26 +28,38 @@ using namespace dev::eth;
 //#define BOOST_THROW_EXCEPTION(X) ((cerr << "VM EXCEPTION " << boost::diagnostic_information(X) << endl), abort())
 
 // consolidate exception throws to avoid spraying boost code all over interpreter
-void dev::eth::throwVMException(VMException x)
+
+void VM::throwOutOfGas()
 {
-	BOOST_THROW_EXCEPTION(x);
+	BOOST_THROW_EXCEPTION(OutOfGas());
 }
 
-void VM::throwVMStackException(unsigned _size, unsigned _n, unsigned _d)
+void VM::throwBadInstruction()
+{
+	BOOST_THROW_EXCEPTION(BadInstruction());
+}
+
+void VM::throwBadJumpDestination()
+{
+	BOOST_THROW_EXCEPTION(BadJumpDestination());
+}
+
+void VM::throwBadStack(unsigned _size, unsigned _n, unsigned _d)
 {
 	if (_size < _n)
 	{
 		if (m_onFail)
 			(this->*m_onFail)();
-		throwVMException(StackUnderflow() << RequirementError((bigint)_n, (bigint)_size));
+		BOOST_THROW_EXCEPTION(StackUnderflow() << RequirementError((bigint)_n, (bigint)_size));
 	}
 	if (_size - _n + _d > 1024)
 	{
 		if (m_onFail)
 			(this->*m_onFail)();
-		throwVMException(OutOfStack() << RequirementError((bigint)(_d - _n), (bigint)_size));
+		BOOST_THROW_EXCEPTION(OutOfStack() << RequirementError((bigint)(_d - _n), (bigint)_size));
 	}
 }
+
 
 std::array<InstructionMetric, 256> VM::c_metrics;
 void VM::initMetrics()


### PR DESCRIPTION
Move throw of each kind of exception into its own non-inlined function so that all the boost exception code doesn't get inlined in interpreter cases.  @chfast 
