### PR TITLE
use singletest option to specify test file name in stRandom tests

### DIFF
--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -1074,10 +1074,22 @@ bool TestOutputHelper::passTest(json_spirit::mObject& _o, std::string& _testName
 		std::cout << std::endl;
 	}
 
-	if (test::Options::get().singleTest && test::Options::get().singleTestName != _testName)
+	if (test::Options::get().singleTest)
 	{
-		_o.clear();
-		return false;
+		if (m_currentTestCaseName == "stRandom")
+		{
+			if (m_currentTestFileName != test::Options::get().singleTestName &&
+				m_currentTestFileName.substr(0, m_currentTestFileName.length()-5) != test::Options::get().singleTestName)
+			{
+				_o.clear();
+				return false;
+			}
+		}
+		else if (test::Options::get().singleTestName != _testName)
+		{
+			_o.clear();
+			return false;
+		}
 	}
 
 	cnote << _testName;

--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -1074,22 +1074,11 @@ bool TestOutputHelper::passTest(json_spirit::mObject& _o, std::string& _testName
 		std::cout << std::endl;
 	}
 
-	if (test::Options::get().singleTest)
+	if (m_currentTestCaseName != "stRandom")
+	if (test::Options::get().singleTest && test::Options::get().singleTestName != _testName)
 	{
-		if (m_currentTestCaseName == "stRandom")
-		{
-			if (m_currentTestFileName != test::Options::get().singleTestName &&
-				m_currentTestFileName.substr(0, m_currentTestFileName.length()-5) != test::Options::get().singleTestName)
-			{
-				_o.clear();
-				return false;
-			}
-		}
-		else if (test::Options::get().singleTestName != _testName)
-		{
-			_o.clear();
-			return false;
-		}
+		_o.clear();
+		return false;
 	}
 
 	cnote << _testName;

--- a/test/libethereum/State.cpp
+++ b/test/libethereum/State.cpp
@@ -337,7 +337,17 @@ BOOST_AUTO_TEST_CASE(stRandom)
 		boost::filesystem::directory_iterator iterator(fillersPath);
 		for(; iterator != boost::filesystem::directory_iterator(); ++iterator)
 			if (boost::filesystem::is_regular_file(iterator->path()) && iterator->path().extension() == ".json")
-				testFiles.push_back(iterator->path());
+			{
+				if (test::Options::get().singleTest)
+				{
+					string fileboost = iterator->path().filename().string();
+					string filesingletest = test::Options::get().singleTestName; //parse singletest as a filename of random test
+					if (fileboost == filesingletest || fileboost.substr(0, fileboost.length()-5) == filesingletest)
+						testFiles.push_back(iterator->path());
+				}
+				else
+					testFiles.push_back(iterator->path());
+			}
 
 		test::TestOutputHelper::setMaxTests(testFiles.size() * 2);
 		for (auto& path: testFiles)
@@ -347,6 +357,7 @@ BOOST_AUTO_TEST_CASE(stRandom)
 			filename = filename.substr(0, filename.length() - 5); //without .json
 			dev::test::executeTests(filename, "/StateTests/RandomTests",dev::test::getFolder(__FILE__) + "/StateTestsFiller/RandomTests", dev::test::doStateTests, false);
 		}
+		return; //executeTests has already run test after filling
 	}
 
 	string testPath = dev::test::getTestPath();
@@ -356,7 +367,17 @@ BOOST_AUTO_TEST_CASE(stRandom)
 	boost::filesystem::directory_iterator iterator(testPath);
 	for(; iterator != boost::filesystem::directory_iterator(); ++iterator)
 		if (boost::filesystem::is_regular_file(iterator->path()) && iterator->path().extension() == ".json")
-			testFiles.push_back(iterator->path());
+		{
+			if (test::Options::get().singleTest)
+			{
+				string fileboost = iterator->path().filename().string();
+				string filesingletest = test::Options::get().singleTestName; //parse singletest as a filename of random test
+				if (fileboost == filesingletest || fileboost.substr(0, fileboost.length()-5) == filesingletest)
+					testFiles.push_back(iterator->path());
+			}
+			else
+				testFiles.push_back(iterator->path());
+		}
 
 	test::TestOutputHelper::initTest();
 	test::TestOutputHelper::setMaxTests(testFiles.size());


### PR DESCRIPTION
Bob is currently debuggin StateTests and for randomTests this option should choose test by it's filename not by the testname inside a file
